### PR TITLE
feat(Style): add localization

### DIFF
--- a/schemas/csl-style-schema.json
+++ b/schemas/csl-style-schema.json
@@ -812,6 +812,15 @@
             "description": "The machine-readable token that uniquely identifies the style.",
             "type": "string"
         },
+        "localization": {
+            "default": "global",
+            "description": "The scope to use for localized terms.",
+            "enum": [
+                "global",
+                "per-item"
+            ],
+            "type": "string"
+        },
         "templates": {
             "description": "Template definitions, for use elsewhere in the style.",
             "items": {

--- a/src/style.ts
+++ b/src/style.ts
@@ -193,6 +193,12 @@ interface Style {
    */
   categories?: CategoryType[];
   /**
+   * The scope to use for localized terms.
+   * 
+   * @default global
+   */
+  localization?: "per-item" | "global";
+  /**
    * Template definitions, for use elsewhere in the style.
    */
   templates?: NamedTemplate[];


### PR DESCRIPTION
A property to set the rule for use of term locales in documents.

The default option is "global", but there is also an option for "per-item".

When coupled with the "locale" conditional, this should (I hope) provide support for multi-lingual formatting, or at least important components of it.

This assumes it would only be a global setting; that one wouldn't want to somehow set citation and bibliography differently.

If this makes sense, it could be a sensible thing to add to CSL 1.x.