### PR TITLE
rely more on parameters than conditional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ VERSION=$(shell grep '\"version\":' package.json | sed -e 's/.*: \"\([^"]*\)".*/
 default: schemas
 
 schemas:
-	npx typescript-json-schema --required --noExtraProps src/style.ts Style -o schemas/csl-style-schema.json
-	npx typescript-json-schema --required --noExtraProps src/reference.ts Reference -o schemas/csl-reference-schema.json
+	npx typescript-json-schema --refs --aliasRefs --required --noExtraProps src/style.ts Style -o schemas/csl-style-schema.json
+	npx typescript-json-schema --refs --aliasRefs --required --noExtraProps src/reference.ts Reference -o schemas/csl-reference-schema.json
 
 build:
 	npx tsc

--- a/examples/style.csl.yaml
+++ b/examples/style.csl.yaml
@@ -1,28 +1,29 @@
-# yaml-language-server: $schema=/home/bruce/Code/csl-next.js/schemas/csl-style-schema.json
+# yaml-language-server: $schema=/home/bruce/Code/csl-next.js/schemas/csl-style-schema.json 
 ---
+# this is a flatter model, relying more heavily on parameters
 title: APA
-id: apa
-description: APA style
 citation:
+  # in CSL 1.0, we have this global, but it's specific to citations
+  placement: inline
+  # There's only so many ways to sort and group, so let's just itemize them
+  sort: cs-author-year
+  groupBy: cs-author-year
+  # again: another example where there are only a few options
+  groupAffix: parentheses # maybe would need localizing though?
+  # andAs is a property of lists, in this case the citation
+  andAs: term
+  delimiter: semi-colon
+  contexts:
+    - integral:
+        # maybe a little dicey, but to keep format simpler
+        groupAffixLevel: secondary
+        # here we override andAs for this mode
+        andAs: symbol
+        delimiter: comma
   format:
-    - when:
-        - mode: narrative
-          format:
-            - groupBy: cs-author
-              delimiter: ", "
-              andAs: symbol
-              format:
-                - groupBy: cs-year
-                  prefix: (
-                  suffix: )
-                  format:
-                    - variable: issued
-      else:
-        - groupBy: cs-author-year # not sure this grouping is right
-          prefix: (
-          suffix: )
-          delimiter: "; "
-          format:
-            - template: author-apa
-            - variable: issued
-  
+    # in this example, no need for conditional here
+    # configure delimiters in parameters
+    # author-date styles are such a hassle at this level!
+    - template: author-apa
+    - template: year
+    - template: locators-apa

--- a/examples/style.csl.yaml
+++ b/examples/style.csl.yaml
@@ -10,8 +10,6 @@ citation:
   groupBy: cs-author-year
   # again: another example where there are only a few options
   groupAffix: parentheses # maybe would need localizing though?
-  # andAs is a property of lists, in this case the citation
-  andAs: term
   delimiter: semi-colon
   contexts:
     - integral:
@@ -20,6 +18,8 @@ citation:
         # here we override andAs for this mode
         andAs: symbol
         delimiter: comma
+    - nonIntegral:
+        groupAffixLevel: primary
   format:
     # in this example, no need for conditional here
     # configure delimiters in parameters

--- a/schemas/csl-reference-schema.json
+++ b/schemas/csl-reference-schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "additionalProperties": false,
     "definitions": {
+        "CSLDate": {
+            "type": "string"
+        },
         "Contributor": {
             "additionalProperties": false,
             "properties": {
@@ -56,14 +59,17 @@
                 }
             ]
         },
+        "TitleString": {
+            "type": "string"
+        },
         "TitleStructured": {
             "additionalProperties": false,
             "properties": {
                 "full": {
-                    "type": "string"
+                    "$ref": "#/definitions/TitleString"
                 },
                 "main": {
-                    "type": "string"
+                    "$ref": "#/definitions/TitleString"
                 },
                 "sub": {
                     "items": {
@@ -90,7 +96,7 @@
             "$ref": "#/definitions/ID"
         },
         "issued": {
-            "type": "string"
+            "$ref": "#/definitions/CSLDate"
         },
         "title": {
             "anyOf": [

--- a/schemas/csl-style-schema.json
+++ b/schemas/csl-style-schema.json
@@ -237,6 +237,20 @@
             ],
             "type": "string"
         },
+        "GroupAffixLevel": {
+            "enum": [
+                "primary",
+                "secondary"
+            ],
+            "type": "string"
+        },
+        "GroupAffixType": {
+            "enum": [
+                "brackets",
+                "parentheses"
+            ],
+            "type": "string"
+        },
         "GroupSortType": {
             "enum": [
                 "cs-as-cited",
@@ -304,6 +318,15 @@
                         "$ref": "#/definitions/TemplateModel"
                     },
                     "type": "array"
+                },
+                "groupAffix": {
+                    "$ref": "#/definitions/GroupAffixType",
+                    "description": "The affix to use to enclose a group within a list; for example, a citation."
+                },
+                "groupAffixLevel": {
+                    "$ref": "#/definitions/GroupAffixLevel",
+                    "default": "primary",
+                    "description": "The group-level to apply groupAffix to.\nA standard citation, for example, would be the default \"primary\", since it applies to the citation as a whole.\nA narrative citation, by contrast, would be \"secondary\", because it applies to the \"year\" group."
                 },
                 "groupBy": {
                     "$ref": "#/definitions/GroupSortType",
@@ -373,6 +396,15 @@
                     },
                     "type": "array"
                 },
+                "groupAffix": {
+                    "$ref": "#/definitions/GroupAffixType",
+                    "description": "The affix to use to enclose a group within a list; for example, a citation."
+                },
+                "groupAffixLevel": {
+                    "$ref": "#/definitions/GroupAffixLevel",
+                    "default": "primary",
+                    "description": "The group-level to apply groupAffix to.\nA standard citation, for example, would be the default \"primary\", since it applies to the citation as a whole.\nA narrative citation, by contrast, would be \"secondary\", because it applies to the \"year\" group."
+                },
                 "groupBy": {
                     "$ref": "#/definitions/GroupSortType",
                     "description": "How to group the list of reference items in a citation or bibliography."
@@ -436,6 +468,15 @@
                         "$ref": "#/definitions/TemplateModel"
                     },
                     "type": "array"
+                },
+                "groupAffix": {
+                    "$ref": "#/definitions/GroupAffixType",
+                    "description": "The affix to use to enclose a group within a list; for example, a citation."
+                },
+                "groupAffixLevel": {
+                    "$ref": "#/definitions/GroupAffixLevel",
+                    "default": "primary",
+                    "description": "The group-level to apply groupAffix to.\nA standard citation, for example, would be the default \"primary\", since it applies to the citation as a whole.\nA narrative citation, by contrast, would be \"secondary\", because it applies to the \"year\" group."
                 },
                 "groupBy": {
                     "$ref": "#/definitions/GroupSortType",
@@ -532,6 +573,15 @@
                         "$ref": "#/definitions/TemplateModel"
                     },
                     "type": "array"
+                },
+                "groupAffix": {
+                    "$ref": "#/definitions/GroupAffixType",
+                    "description": "The affix to use to enclose a group within a list; for example, a citation."
+                },
+                "groupAffixLevel": {
+                    "$ref": "#/definitions/GroupAffixLevel",
+                    "default": "primary",
+                    "description": "The group-level to apply groupAffix to.\nA standard citation, for example, would be the default \"primary\", since it applies to the citation as a whole.\nA narrative citation, by contrast, would be \"secondary\", because it applies to the \"year\" group."
                 },
                 "groupBy": {
                     "$ref": "#/definitions/GroupSortType",
@@ -684,6 +734,15 @@
                         "$ref": "#/definitions/TemplateModel"
                     },
                     "type": "array"
+                },
+                "groupAffix": {
+                    "$ref": "#/definitions/GroupAffixType",
+                    "description": "The affix to use to enclose a group within a list; for example, a citation."
+                },
+                "groupAffixLevel": {
+                    "$ref": "#/definitions/GroupAffixLevel",
+                    "default": "primary",
+                    "description": "The group-level to apply groupAffix to.\nA standard citation, for example, would be the default \"primary\", since it applies to the citation as a whole.\nA narrative citation, by contrast, would be \"secondary\", because it applies to the \"year\" group."
                 },
                 "groupBy": {
                     "$ref": "#/definitions/GroupSortType",

--- a/schemas/csl-style-schema.json
+++ b/schemas/csl-style-schema.json
@@ -2,6 +2,82 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "additionalProperties": false,
     "definitions": {
+        "Bibliography": {
+            "additionalProperties": false,
+            "properties": {
+                "andAs": {
+                    "enum": [
+                        "symbol",
+                        "term"
+                    ],
+                    "type": "string"
+                },
+                "bold": {
+                    "type": "boolean"
+                },
+                "delimiter": {
+                    "type": "string"
+                },
+                "emph": {
+                    "type": "boolean"
+                },
+                "format": {
+                    "items": {
+                        "$ref": "#/definitions/TemplateModel"
+                    },
+                    "type": "array"
+                },
+                "groupAffix": {
+                    "$ref": "#/definitions/GroupAffixType",
+                    "description": "The affix to use to enclose a group within a list; for example, a citation."
+                },
+                "groupAffixLevel": {
+                    "$ref": "#/definitions/GroupAffixLevel",
+                    "default": "primary",
+                    "description": "The group-level to apply groupAffix to.\nA standard citation, for example, would be the default \"primary\", since it applies to the citation as a whole.\nA narrative citation, by contrast, would be \"secondary\", because it applies to the \"year\" group."
+                },
+                "groupBy": {
+                    "$ref": "#/definitions/GroupSortType",
+                    "description": "How to group the list of reference items in a citation or bibliography."
+                },
+                "heading": {
+                    "type": "string"
+                },
+                "inline": {
+                    "description": "Render the list inlne; otherwise block.",
+                    "type": "boolean"
+                },
+                "listStyle": {
+                    "type": "string"
+                },
+                "prefix": {
+                    "description": "The string to insert before the content.",
+                    "type": "string"
+                },
+                "quote": {
+                    "type": "boolean"
+                },
+                "shortenMin": {
+                    "type": "number"
+                },
+                "shortenUse": {
+                    "type": "number"
+                },
+                "sort": {
+                    "$ref": "#/definitions/GroupSortType",
+                    "description": "How to sort the reference items in citation or bibliography."
+                },
+                "suffix": {
+                    "description": "The string to insert after the content.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "heading",
+                "listStyle"
+            ],
+            "type": "object"
+        },
         "CategoryType": {
             "enum": [
                 "biology",
@@ -9,6 +85,93 @@
                 "social science"
             ],
             "type": "string"
+        },
+        "Citation": {
+            "additionalProperties": false,
+            "properties": {
+                "andAs": {
+                    "enum": [
+                        "symbol",
+                        "term"
+                    ],
+                    "type": "string"
+                },
+                "bold": {
+                    "type": "boolean"
+                },
+                "contexts": {
+                    "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                            "integral": {
+                                "$ref": "#/definitions/RefList",
+                                "description": "Integral citations are those where the author is printed inline in the text; aka \"in text\" or \"narrative\" citations."
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "delimiter": {
+                    "type": "string"
+                },
+                "emph": {
+                    "type": "boolean"
+                },
+                "format": {
+                    "items": {
+                        "$ref": "#/definitions/TemplateModel"
+                    },
+                    "type": "array"
+                },
+                "groupAffix": {
+                    "$ref": "#/definitions/GroupAffixType",
+                    "description": "The affix to use to enclose a group within a list; for example, a citation."
+                },
+                "groupAffixLevel": {
+                    "$ref": "#/definitions/GroupAffixLevel",
+                    "default": "primary",
+                    "description": "The group-level to apply groupAffix to.\nA standard citation, for example, would be the default \"primary\", since it applies to the citation as a whole.\nA narrative citation, by contrast, would be \"secondary\", because it applies to the \"year\" group."
+                },
+                "groupBy": {
+                    "$ref": "#/definitions/GroupSortType",
+                    "description": "How to group the list of reference items in a citation or bibliography."
+                },
+                "inline": {
+                    "description": "Render the list inlne; otherwise block.",
+                    "type": "boolean"
+                },
+                "placement": {
+                    "default": "inline",
+                    "enum": [
+                        "inline",
+                        "note"
+                    ],
+                    "type": "string"
+                },
+                "prefix": {
+                    "description": "The string to insert before the content.",
+                    "type": "string"
+                },
+                "quote": {
+                    "type": "boolean"
+                },
+                "shortenMin": {
+                    "type": "number"
+                },
+                "shortenUse": {
+                    "type": "number"
+                },
+                "sort": {
+                    "$ref": "#/definitions/GroupSortType",
+                    "description": "How to sort the reference items in citation or bibliography."
+                },
+                "suffix": {
+                    "description": "The string to insert after the content.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
         },
         "Cond": {
             "additionalProperties": false,
@@ -74,11 +237,8 @@
                             "type": "array"
                         },
                         "isEDTFDate": {
-                            "description": "Does the date conform to EDTF?",
-                            "enum": [
-                                "issued"
-                            ],
-                            "type": "string"
+                            "$ref": "#/definitions/DateType",
+                            "description": "Does the date conform to EDTF?"
                         },
                         "match": {
                             "default": "all",
@@ -237,214 +397,7 @@
             ],
             "type": "string"
         },
-        "GroupAffixLevel": {
-            "enum": [
-                "primary",
-                "secondary"
-            ],
-            "type": "string"
-        },
-        "GroupAffixType": {
-            "enum": [
-                "brackets",
-                "parentheses"
-            ],
-            "type": "string"
-        },
-        "GroupSortType": {
-            "enum": [
-                "cs-as-cited",
-                "cs-author",
-                "cs-author-year",
-                "cs-year"
-            ],
-            "type": "string"
-        },
-        "LocatorType": {
-            "enum": [
-                "chapter",
-                "page"
-            ],
-            "type": "string"
-        },
-        "ModeType": {
-            "enum": [
-                "default",
-                "narrative"
-            ],
-            "type": "string"
-        },
-        "NamedTemplate": {
-            "additionalProperties": false,
-            "properties": {
-                "name": {
-                    "description": "The name token for the template, for reference from other templates.",
-                    "type": "string"
-                },
-                "template": {
-                    "items": {
-                        "$ref": "#/definitions/TemplateModel"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "name",
-                "template"
-            ],
-            "type": "object"
-        },
-        "RefItemBibliographyList": {
-            "additionalProperties": false,
-            "properties": {
-                "andAs": {
-                    "enum": [
-                        "symbol",
-                        "term"
-                    ],
-                    "type": "string"
-                },
-                "bold": {
-                    "type": "boolean"
-                },
-                "delimiter": {
-                    "type": "string"
-                },
-                "emph": {
-                    "type": "boolean"
-                },
-                "format": {
-                    "items": {
-                        "$ref": "#/definitions/TemplateModel"
-                    },
-                    "type": "array"
-                },
-                "groupAffix": {
-                    "$ref": "#/definitions/GroupAffixType",
-                    "description": "The affix to use to enclose a group within a list; for example, a citation."
-                },
-                "groupAffixLevel": {
-                    "$ref": "#/definitions/GroupAffixLevel",
-                    "default": "primary",
-                    "description": "The group-level to apply groupAffix to.\nA standard citation, for example, would be the default \"primary\", since it applies to the citation as a whole.\nA narrative citation, by contrast, would be \"secondary\", because it applies to the \"year\" group."
-                },
-                "groupBy": {
-                    "$ref": "#/definitions/GroupSortType",
-                    "description": "How to group the list of reference items in a citation or bibliography."
-                },
-                "heading": {
-                    "type": "string"
-                },
-                "inline": {
-                    "description": "Render the list inlne; otherwise block.",
-                    "type": "boolean"
-                },
-                "listStyle": {
-                    "type": "string"
-                },
-                "prefix": {
-                    "description": "The string to insert before the content.",
-                    "type": "string"
-                },
-                "quote": {
-                    "type": "boolean"
-                },
-                "shortenMin": {
-                    "type": "number"
-                },
-                "shortenUse": {
-                    "type": "number"
-                },
-                "sort": {
-                    "$ref": "#/definitions/GroupSortType",
-                    "description": "How to sort the reference items in citation or bibliography."
-                },
-                "suffix": {
-                    "description": "The string to insert after the content.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "format",
-                "heading",
-                "listStyle"
-            ],
-            "type": "object"
-        },
-        "RefItemCitationList": {
-            "additionalProperties": false,
-            "properties": {
-                "andAs": {
-                    "enum": [
-                        "symbol",
-                        "term"
-                    ],
-                    "type": "string"
-                },
-                "bold": {
-                    "type": "boolean"
-                },
-                "delimiter": {
-                    "type": "string"
-                },
-                "emph": {
-                    "type": "boolean"
-                },
-                "format": {
-                    "items": {
-                        "$ref": "#/definitions/TemplateModel"
-                    },
-                    "type": "array"
-                },
-                "groupAffix": {
-                    "$ref": "#/definitions/GroupAffixType",
-                    "description": "The affix to use to enclose a group within a list; for example, a citation."
-                },
-                "groupAffixLevel": {
-                    "$ref": "#/definitions/GroupAffixLevel",
-                    "default": "primary",
-                    "description": "The group-level to apply groupAffix to.\nA standard citation, for example, would be the default \"primary\", since it applies to the citation as a whole.\nA narrative citation, by contrast, would be \"secondary\", because it applies to the \"year\" group."
-                },
-                "groupBy": {
-                    "$ref": "#/definitions/GroupSortType",
-                    "description": "How to group the list of reference items in a citation or bibliography."
-                },
-                "inline": {
-                    "default": true,
-                    "description": "Render the list inlne; otherwise block.",
-                    "enum": [
-                        true
-                    ],
-                    "type": "boolean"
-                },
-                "prefix": {
-                    "description": "The string to insert before the content.",
-                    "type": "string"
-                },
-                "quote": {
-                    "type": "boolean"
-                },
-                "shortenMin": {
-                    "type": "number"
-                },
-                "shortenUse": {
-                    "type": "number"
-                },
-                "sort": {
-                    "$ref": "#/definitions/GroupSortType",
-                    "description": "How to sort the reference items in citation or bibliography."
-                },
-                "suffix": {
-                    "description": "The string to insert after the content.",
-                    "type": "string"
-                }
-            },
-            "required": [
-                "format"
-            ],
-            "type": "object"
-        },
-        "RefItemContributorList": {
+        "Contributors": {
             "additionalProperties": false,
             "properties": {
                 "andAs": {
@@ -512,44 +465,47 @@
                 }
             },
             "required": [
-                "format",
                 "variable"
             ],
             "type": "object"
         },
-        "RefItemDate": {
-            "additionalProperties": false,
-            "properties": {
-                "bold": {
-                    "type": "boolean"
-                },
-                "emph": {
-                    "type": "boolean"
-                },
-                "prefix": {
-                    "description": "The string to insert before the content.",
-                    "type": "string"
-                },
-                "quote": {
-                    "type": "boolean"
-                },
-                "suffix": {
-                    "description": "The string to insert after the content.",
-                    "type": "string"
-                },
-                "variable": {
-                    "enum": [
-                        "issued"
-                    ],
-                    "type": "string"
-                }
-            },
-            "required": [
-                "variable"
+        "DateType": {
+            "enum": [
+                "issued"
             ],
-            "type": "object"
+            "type": "string"
         },
-        "RefItemLocatorList": {
+        "GroupAffixLevel": {
+            "enum": [
+                "primary",
+                "secondary"
+            ],
+            "type": "string"
+        },
+        "GroupAffixType": {
+            "enum": [
+                "brackets",
+                "parentheses"
+            ],
+            "type": "string"
+        },
+        "GroupSortType": {
+            "enum": [
+                "cs-as-cited",
+                "cs-author",
+                "cs-author-year",
+                "cs-year"
+            ],
+            "type": "string"
+        },
+        "LocatorType": {
+            "enum": [
+                "chapter",
+                "page"
+            ],
+            "type": "string"
+        },
+        "Locators": {
             "additionalProperties": false,
             "properties": {
                 "andAs": {
@@ -617,7 +573,62 @@
                 }
             },
             "required": [
-                "format",
+                "variable"
+            ],
+            "type": "object"
+        },
+        "ModeType": {
+            "enum": [
+                "default",
+                "narrative"
+            ],
+            "type": "string"
+        },
+        "NamedTemplate": {
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "description": "The name token for the template, for reference from other templates.",
+                    "type": "string"
+                },
+                "template": {
+                    "items": {
+                        "$ref": "#/definitions/TemplateModel"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "name",
+                "template"
+            ],
+            "type": "object"
+        },
+        "RefItemDate": {
+            "additionalProperties": false,
+            "properties": {
+                "bold": {
+                    "type": "boolean"
+                },
+                "emph": {
+                    "type": "boolean"
+                },
+                "prefix": {
+                    "description": "The string to insert before the content.",
+                    "type": "string"
+                },
+                "quote": {
+                    "type": "boolean"
+                },
+                "suffix": {
+                    "description": "The string to insert after the content.",
+                    "type": "string"
+                },
+                "variable": {
+                    "$ref": "#/definitions/DateType"
+                }
+            },
+            "required": [
                 "variable"
             ],
             "type": "object"
@@ -678,35 +689,6 @@
             },
             "required": [
                 "template"
-            ],
-            "type": "object"
-        },
-        "RefItemTitle": {
-            "additionalProperties": false,
-            "properties": {
-                "bold": {
-                    "type": "boolean"
-                },
-                "emph": {
-                    "type": "boolean"
-                },
-                "prefix": {
-                    "description": "The string to insert before the content.",
-                    "type": "string"
-                },
-                "quote": {
-                    "type": "boolean"
-                },
-                "suffix": {
-                    "description": "The string to insert after the content.",
-                    "type": "string"
-                },
-                "variable": {
-                    "$ref": "#/definitions/TitleType"
-                }
-            },
-            "required": [
-                "variable"
             ],
             "type": "object"
         },
@@ -774,9 +756,6 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "format"
-            ],
             "type": "object"
         },
         "RefType": {
@@ -807,21 +786,50 @@
                     "$ref": "#/definitions/RefItemSimple"
                 },
                 {
-                    "$ref": "#/definitions/RefItemContributorList"
+                    "$ref": "#/definitions/Contributors"
                 },
                 {
-                    "$ref": "#/definitions/RefItemLocatorList"
+                    "$ref": "#/definitions/Locators"
                 },
                 {
                     "$ref": "#/definitions/RefItemDate"
                 },
                 {
-                    "$ref": "#/definitions/RefItemTitle"
+                    "$ref": "#/definitions/Title"
                 },
                 {
                     "$ref": "#/definitions/Cond"
                 }
             ]
+        },
+        "Title": {
+            "additionalProperties": false,
+            "properties": {
+                "bold": {
+                    "type": "boolean"
+                },
+                "emph": {
+                    "type": "boolean"
+                },
+                "prefix": {
+                    "description": "The string to insert before the content.",
+                    "type": "string"
+                },
+                "quote": {
+                    "type": "boolean"
+                },
+                "suffix": {
+                    "description": "The string to insert after the content.",
+                    "type": "string"
+                },
+                "variable": {
+                    "$ref": "#/definitions/TitleType"
+                }
+            },
+            "required": [
+                "variable"
+            ],
+            "type": "object"
         },
         "TitleType": {
             "enum": [
@@ -850,7 +858,7 @@
     },
     "properties": {
         "bibliography": {
-            "$ref": "#/definitions/RefItemBibliographyList",
+            "$ref": "#/definitions/Bibliography",
             "description": "The bibliography specification."
         },
         "categories": {
@@ -861,7 +869,7 @@
             "type": "array"
         },
         "citation": {
-            "$ref": "#/definitions/RefItemCitationList",
+            "$ref": "#/definitions/Citation",
             "description": "The citation specification."
         },
         "description": {

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,0 +1,68 @@
+// REVIEW not sure where best to do this
+type Lang =
+  | "af-ZA"
+  | "ar"
+  | "bg-BG"
+  | "ca-AD"
+  | "cs-CZ"
+  | "da-DK"
+  | "de-AT"
+  | "de-CH"
+  | "de-DE"
+  | "el-GR"
+  | "en-GB"
+  | "en-US"
+  | "es-ES"
+  | "et-EE"
+  | "eu"
+  | "fa-IR"
+  | "fi-FI"
+  | "fr-CA"
+  | "fr-FR"
+  | "he-IL"
+  | "hr-HR"
+  | "hu-HU"
+  | "is-IS"
+  | "it-IT"
+  | "ja-JP"
+  | "km-KH"
+  | "ko-KR"
+  | "lt-LT"
+  | "lv-LV"
+  | "mn-MN"
+  | "nb-NO"
+  | "nl-NL"
+  | "pl-PL"
+  | "pt-BR"
+  | "pt-PT"
+  | "ro-RO"
+  | "ru-RU"
+  | "sk-SK"
+  | "sl-SI"
+  | "sr-RS"
+  | "sv-SE"
+  | "th-TH"
+  | "tr-TR"
+  | "uk-UA"
+  | "vi-VN"
+  | "zh-CN"
+  | "zh-TW";
+
+interface Locale {
+  translators?: string;
+  rights?: string; // use enum here, and in style
+  locale: Lang; // https://github.com/anton-bot/locale-enum
+  punctuationInQuote: boolean;
+  terms: Term[];
+}
+
+interface Term {
+  name: string;
+  form?: "short" | "symbol";
+  single?: string;
+  multiple?: string; // TODO this and above need to be coupled
+}
+
+interface DateTerm extends Term {
+  dateParts: string[]; // TODO
+}

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -5,11 +5,11 @@
 //   - page 23, 25-36
 //   - chapter IV
 
-type Locator = (string | number | number[]);
+type Locator = string | number | number[];
 
 // REVIEW this approach is more human-friendly, but maybe better to just have explicit type/value properties?
 // In any case, this is just a place holder ATM.
 interface Locators {
-    pages?: Locator;
-    chapter?: Locator;
+  pages?: Locator;
+  chapter?: Locator;
 }

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -9,33 +9,31 @@ type ID = string | number; // string needs to be a token
 type ReferenceType =
   | "book"
   | "article"
-  | "chapter"
-  ;
+  | "chapter";
 
 type RoleType =
   | "author"
   | "editor"
-  | "publisher"
-  ;
+  | "publisher";
 
-type Title = TitleStructured | TitleString
+type Title = TitleStructured | TitleString;
 
 type TitleString = string; // plain or Djot?
 
 // Interfaces
 
 interface TitleStructured {
-    full?: TitleString;
-    main: TitleString;
-    sub: TitleString[];
+  full?: TitleString;
+  main: TitleString;
+  sub: TitleString[];
 }
 
 interface Reference {
-    id: ID;
-    type: ReferenceType;
-    author?: Contributor[]; // fix
-    title?: (Title|Title[]); // REVIEW is this too much flexibility?
-    issued: CSLDate;
+  id: ID;
+  type: ReferenceType;
+  author?: Contributor[]; // fix
+  title?: Title | Title[]; // REVIEW is this too much flexibility?
+  issued: CSLDate;
 }
 
 interface Contributor {
@@ -49,4 +47,3 @@ interface PersonalContributor extends Contributor {
   familyName: string;
   givenName: string;
 }
-

--- a/src/style.ts
+++ b/src/style.ts
@@ -273,8 +273,17 @@ interface RefList extends HasFormatting {
    */
   inline?: boolean;
   delimiter?: string;
+  /**
+   * The integer length of a list that turns on shortening.
+   */
   shortenMin?: number; // integer
+  /**
+   * The integer length of items to take from the list when shortening.
+   */
   shortenUse?: number; // integer; TODO this and the above need to be coupled
+  /**
+   * The string to join the last two items of a list; '&' vs 'and'.
+   */
   andAs?: "symbol" | "term";
   format?: TemplateModel[]; // REVIEW
 }

--- a/src/style.ts
+++ b/src/style.ts
@@ -102,6 +102,16 @@ type TemplateModel =
   | Cond
   ;
 
+type GroupAffixType =
+  | "parentheses"
+  | "brackets"
+  ;
+
+type GroupAffixLevel =
+  | "primary"
+  | "secondary"
+  ;
+
 // eg liquid or mustache option for dev?
 type StringTemplate = string;
 
@@ -242,6 +252,18 @@ interface RefList extends HasFormatting {
    * How to group the list of reference items in a citation or bibliography.
    */
   groupBy?: GroupSortType;
+  /**
+   * The affix to use to enclose a group within a list; for example, a citation.
+   */
+  groupAffix?: GroupAffixType;
+  /**
+   * The group-level to apply groupAffix to.
+   * A standard citation, for example, would be the default "primary", since it applies to the citation as a whole.
+   * A narrative citation, by contrast, would be "secondary", because it applies to the "year" group.
+   * 
+   * @default primary
+   */
+  groupAffixLevel?: GroupAffixLevel;
   /**
    * How to sort the reference items in citation or bibliography.
    */

--- a/src/style.ts
+++ b/src/style.ts
@@ -1,6 +1,6 @@
 // Experimental CSL NEXT typescript model
 
-import { CSLDate } from "./date";
+import { CSLDate } from "./date.ts";
 
 // Doesn't actually do anything ATM, other than generate a JSON Schema.
 // I don't ATM understand distinction between `interface` and `type`
@@ -23,94 +23,85 @@ interface HasFormatting {
 }
 
 type ModeType =
-/**
- * @default "default"
- */
+  /**
+   * @default "default"
+   */
   | "default"
-  | "narrative"
-  ;
+  | "narrative";
 
 type GroupSortType =
   | "cs-author"
   | "cs-year"
   | "cs-author-year"
-  | "cs-as-cited"
-  ;
+  | "cs-as-cited";
 
 type CategoryType =
   | "science"
   | "social science"
-  | "biology"
-  ;
+  | "biology";
 
 // extract, so can reuse elsewhere
 type RefType =
   | "book"
   | "article"
-  | "chapter"
-  ;
+  | "chapter";
 
 type ContributorType =
   | "author"
   | "editor"
-  | "publisher"
-  ;
+  | "publisher";
 
-type DateType =
-  | "issued"
-  ;
+type DateType = "issued";
 
 type TitleType =
   | "title"
-  | "container-title"
-  ;
+  | "container-title";
 
 type LocatorType =
   | "page"
-  | "chapter"
-  ;
+  | "chapter";
 
 type SimpleType =
   | "volume"
   | "issue"
-  | "pages"
-  ;
+  | "pages";
 
 // extract, so can reuse elsewhere
-type VariableType = RefType | ContributorType | DateType | TitleType | SimpleType;
+type VariableType =
+  | RefType
+  | ContributorType
+  | DateType
+  | TitleType
+  | SimpleType;
 
 type MatchType =
   /**
    * Which of the match conditions must be satisfied for it be true?
-   * 
+   *
    * @default "all"
    */
   | "all"
   | "any"
-  | "none"
-  ;
+  | "none";
 
 // this is the structured template model
-type TemplateModel = 
-  | RefList  
+type TemplateModel =
+  | RefList
   | RefItemTemplate
-  | RefItemSimple 
+  | RefItemSimple
   | Contributors
   | Locators
   | RefItemDate
   | Title
-  | Cond
-  ;
+  | Cond;
 
 type GroupAffixType =
   | "parentheses"
-  | "brackets"
-  ;
+  | "brackets";
 
 type GroupAffixLevel =
   | "primary"
-  | "secondary"
-  ;
+  | "secondary";
 
 // eg liquid or mustache option for dev?
 type StringTemplate = string;
@@ -128,10 +119,10 @@ interface Cond {
   else?: TemplateModel[];
 }
 
-type Match = { 
+type Match = {
   /**
    * A list of reference item types; if one is true, then return true.
-   * 
+   *
    * @default all
    */
   match?: "all" | "none" | "any";
@@ -139,52 +130,58 @@ type Match = {
    * When a match, process these templates.
    */
   format: TemplateModel[];
-}
+};
 
-type IsNumber = { 
+type IsNumber = {
   /**
-   * Is the item variable a number?   
+   * Is the item variable a number?
    */
-  isNumber: LocatorType; 
-}
+  isNumber: LocatorType;
+};
 
-type IsEDTFDate = { 
+type IsEDTFDate = {
   /**
    * Does the date conform to EDTF?
    */
-  isEDTFDate: DateType; 
-}
+  isEDTFDate: DateType;
+};
 
-type IsRefType = { 
+type IsRefType = {
   /**
    * Is the item reference type among the listed reference types?
    */
-  isRefType: RefType[]; 
-}
+  isRefType: RefType[];
+};
 
-type HasVariable = { 
+type HasVariable = {
   /**
    * Does the item reference include one of the listed variables?
    */
-  hasVariable: VariableType[]; 
-}
+  hasVariable: VariableType[];
+};
 
-type Locale = { 
+type Locale = {
   /**
    * The item reference locale; to allow multilingual output.
    */
   locale: string; // REVIEW; best place for this? Define the locale type
-}
+};
 
-type Mode = { 
+type Mode = {
   /**
    * The citation mode.
    */
-  mode: ModeType; 
-}
+  mode: ModeType;
+};
 
 // REVIEW hould the below be an interface?
-type DataTypeMatch = IsNumber | IsEDTFDate | IsRefType | HasVariable | Locale | Mode;
+type DataTypeMatch =
+  | IsNumber
+  | IsEDTFDate
+  | IsRefType
+  | HasVariable
+  | Locale
+  | Mode;
 type Condition = Match & DataTypeMatch;
 
 // Style definition
@@ -208,7 +205,7 @@ interface Style {
   categories?: CategoryType[];
   /**
    * The scope to use for localized terms.
-   * 
+   *
    * @default global
    */
   localization?: "per-item" | "global";
@@ -260,7 +257,7 @@ interface RefList extends HasFormatting {
    * The group-level to apply groupAffix to.
    * A standard citation, for example, would be the default "primary", since it applies to the citation as a whole.
    * A narrative citation, by contrast, would be "secondary", because it applies to the "year" group.
-   * 
+   *
    * @default primary
    */
   groupAffixLevel?: GroupAffixLevel;
@@ -289,7 +286,7 @@ interface RefList extends HasFormatting {
 }
 
 interface RefListBlock extends RefList {
-  listStyle: string // TODO
+  listStyle: string; // TODO
 }
 
 // FUNCTIONS
@@ -299,7 +296,7 @@ interface RefListBlock extends RefList {
 type RoleType =
   | "author"
   | "editor"
-  | "publisher"
+  | "publisher";
 
 // contributor modeling needs more thought in general
 // really need to be extracted
@@ -315,11 +312,17 @@ interface PersonalContributor extends Contributor {
   givenName: string;
 }
 
-function formatContributor(contributor: PersonalContributor, role?: string): string {
+function formatContributor(
+  contributor: PersonalContributor,
+  role?: string,
+): string {
   return `${contributor.familyName} ${contributor.givenName}`;
 }
 
-function formatContributorWithRole(contributor: Contributor, role: string): string {
+function formatContributorWithRole(
+  contributor: Contributor,
+  role: string,
+): string {
   return `${contributor.name} ${contributor.role}`;
 }
 
@@ -353,15 +356,27 @@ interface Citation extends RefList {
    * @default inline
    */
   placement?: "inline" | "note";
+  /**
+   * Allows overriding citation parameters and formatting instructions.
+   */
   contexts?: CitationContext[];
 }
 
-type CitationContext = {
+type CitationContext = IntegralCitation | NonIntegralCitation;
+
+type IntegralCitation = {
   /**
    * Integral citations are those where the author is printed inline in the text; aka "in text" or "narrative" citations.
    */
-  integral?: RefList;
-}
+  integral: RefList;
+};
+
+type NonIntegralCitation = {
+  /**
+   * Non-integral citations are those where the author is incorporated in the citation, and not printed inline in the text.
+   */
+  nonIntegral: RefList;
+};
 
 interface Bibliography extends RefListBlock {
   heading: string; // TODO

--- a/src/style.ts
+++ b/src/style.ts
@@ -186,7 +186,7 @@ type Condition = Match & DataTypeMatch;
 
 // Style definition
 
-interface Style {
+export interface Style {
   /**
    * The human-readable name of the style.
    */

--- a/src/style.ts
+++ b/src/style.ts
@@ -95,10 +95,10 @@ type TemplateModel =
   | RefList  
   | RefItemTemplate
   | RefItemSimple 
-  | RefItemContributorList
-  | RefItemLocatorList
+  | Contributors
+  | Locators
   | RefItemDate
-  | RefItemTitle
+  | Title
   | Cond
   ;
 
@@ -219,11 +219,11 @@ interface Style {
   /**
    * The bibliography specification.
    */
-  bibliography?: RefItemBibliographyList;
+  bibliography?: Bibliography;
   /**
    * The citation specification.
    */
-  citation?: RefItemCitationList;
+  citation?: Citation;
 }
 
 interface NamedTemplate {
@@ -276,7 +276,7 @@ interface RefList extends HasFormatting {
   shortenMin?: number; // integer
   shortenUse?: number; // integer; TODO this and the above need to be coupled
   andAs?: "symbol" | "term";
-  format: TemplateModel[]; // REVIEW
+  format?: TemplateModel[]; // REVIEW
 }
 
 interface RefListBlock extends RefList {
@@ -325,27 +325,35 @@ interface RefItemDate extends HasFormatting {
   format?(date: string): string;
 }
 
-interface RefItemTitle extends HasFormatting {
+interface Title extends HasFormatting {
   variable: TitleType;
   main(title: string): string;
   sub(title: string): string;
 }
 
-interface RefItemContributorList extends RefList {
+interface Contributors extends RefList {
   variable: ContributorType;
 }
 
-interface RefItemLocatorList extends RefList {
+interface Locators extends RefList {
   variable: LocatorType;
 }
 
-interface RefItemCitationList extends RefList {
+interface Citation extends RefList {
   /**
-   * @default true
+   * @default inline
    */
-  inline?: true; // REVIEW idea is to set this as default, but this only allow one value
+  placement?: "inline" | "note";
+  contexts?: CitationContext[];
 }
 
-interface RefItemBibliographyList extends RefListBlock {
+type CitationContext = {
+  /**
+   * Integral citations are those where the author is printed inline in the text; aka "in text" or "narrative" citations.
+   */
+  integral?: RefList;
+}
+
+interface Bibliography extends RefListBlock {
   heading: string; // TODO
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
     "outDir": "dist",
     "declaration": true,
     "declarationDir": "types",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
     "isolatedModules": true
   },
   "include": [


### PR DESCRIPTION
 @denismaier -I'm opening this draft branch to see what this might look like more specifically.

I'll segment the possible parameters in discrete commits, so easier to drop if they don't make sense, and can do this iteratively.

Will also try to keep the example file updated.

The commits add:

1. `groupAffix` and `groupAffixLevel` to `RefList`
2. `CitationContext`, with "integral" (intext/narrative) as the only option ATM

BTW, on "integral" vs "non-integral" citations:

I participated in a workshop awhile back at my institution  about citation practices. This is where I learned that terminology. I also learned what is default varies by field. 

In CSL we have always privileged the latter; not sure if that's still sustainable; and if it isn't, what the implications are. Maybe I need to add "non-integral" as an option, and let style authors decide?

Close #13.

-------------

PS - the simpler model also seems well-suited to converting to non-JSON/text formats, like protocol buffers. Here's the example file converted to that, though I don't understand it!

<details>

```protobuf
syntax = "proto3";

message CSLStyle {

    message Integral {
        string groupAffixLevel = 1;
        string andAs = 2;
        string delimiter = 3;
    }

    message Contexts {
        Integral integral = 1;
    }

    message Format {
        string template = 1;
    }

    message Citation {
        string placement = 1;
        string sort = 2;
        string groupBy = 3;
        string groupAffix = 4;
        string andAs = 5;
        string delimiter = 6;
        repeated Contexts contexts = 7;
        repeated Format format = 8;
    }

    string title = 1;
    Citation citation = 2;
}
```

</details>