### PR TITLE
feat: add Disambiguation

### DIFF
--- a/schemas/csl-style-schema.json
+++ b/schemas/csl-style-schema.json
@@ -6,6 +6,7 @@
             "additionalProperties": false,
             "properties": {
                 "andAs": {
+                    "description": "The string to join the last two items of a list; '&' vs 'and'.",
                     "enum": [
                         "symbol",
                         "term"
@@ -58,9 +59,11 @@
                     "type": "boolean"
                 },
                 "shortenMin": {
+                    "description": "The integer length of a list that turns on shortening.",
                     "type": "number"
                 },
                 "shortenUse": {
+                    "description": "The integer length of items to take from the list when shortening.",
                     "type": "number"
                 },
                 "sort": {
@@ -90,6 +93,7 @@
             "additionalProperties": false,
             "properties": {
                 "andAs": {
+                    "description": "The string to join the last two items of a list; '&' vs 'and'.",
                     "enum": [
                         "symbol",
                         "term"
@@ -100,15 +104,9 @@
                     "type": "boolean"
                 },
                 "contexts": {
+                    "description": "Allows overriding citation parameters and formatting instructions.",
                     "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                            "integral": {
-                                "$ref": "#/definitions/RefList",
-                                "description": "Integral citations are those where the author is printed inline in the text; aka \"in text\" or \"narrative\" citations."
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "#/definitions/CitationContext"
                     },
                     "type": "array"
                 },
@@ -157,9 +155,11 @@
                     "type": "boolean"
                 },
                 "shortenMin": {
+                    "description": "The integer length of a list that turns on shortening.",
                     "type": "number"
                 },
                 "shortenUse": {
+                    "description": "The integer length of items to take from the list when shortening.",
                     "type": "number"
                 },
                 "sort": {
@@ -172,6 +172,16 @@
                 }
             },
             "type": "object"
+        },
+        "CitationContext": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/IntegralCitation"
+                },
+                {
+                    "$ref": "#/definitions/NonIntegralCitation"
+                }
+            ]
         },
         "Cond": {
             "additionalProperties": false,
@@ -401,6 +411,7 @@
             "additionalProperties": false,
             "properties": {
                 "andAs": {
+                    "description": "The string to join the last two items of a list; '&' vs 'and'.",
                     "enum": [
                         "symbol",
                         "term"
@@ -447,9 +458,11 @@
                     "type": "boolean"
                 },
                 "shortenMin": {
+                    "description": "The integer length of a list that turns on shortening.",
                     "type": "number"
                 },
                 "shortenUse": {
+                    "description": "The integer length of items to take from the list when shortening.",
                     "type": "number"
                 },
                 "sort": {
@@ -475,6 +488,9 @@
             ],
             "type": "string"
         },
+        "Disambiguation": {
+            "$ref": "#/definitions/__type"
+        },
         "GroupAffixLevel": {
             "enum": [
                 "primary",
@@ -498,6 +514,9 @@
             ],
             "type": "string"
         },
+        "IntegralCitation": {
+            "$ref": "#/definitions/__type_1"
+        },
         "LocatorType": {
             "enum": [
                 "chapter",
@@ -509,6 +528,7 @@
             "additionalProperties": false,
             "properties": {
                 "andAs": {
+                    "description": "The string to join the last two items of a list; '&' vs 'and'.",
                     "enum": [
                         "symbol",
                         "term"
@@ -555,9 +575,11 @@
                     "type": "boolean"
                 },
                 "shortenMin": {
+                    "description": "The integer length of a list that turns on shortening.",
                     "type": "number"
                 },
                 "shortenUse": {
+                    "description": "The integer length of items to take from the list when shortening.",
                     "type": "number"
                 },
                 "sort": {
@@ -603,6 +625,9 @@
                 "template"
             ],
             "type": "object"
+        },
+        "NonIntegralCitation": {
+            "$ref": "#/definitions/__type_2"
         },
         "RefItemDate": {
             "additionalProperties": false,
@@ -696,6 +721,7 @@
             "additionalProperties": false,
             "properties": {
                 "andAs": {
+                    "description": "The string to join the last two items of a list; '&' vs 'and'.",
                     "enum": [
                         "symbol",
                         "term"
@@ -742,9 +768,11 @@
                     "type": "boolean"
                 },
                 "shortenMin": {
+                    "description": "The integer length of a list that turns on shortening.",
                     "type": "number"
                 },
                 "shortenUse": {
+                    "description": "The integer length of items to take from the list when shortening.",
                     "type": "number"
                 },
                 "sort": {
@@ -854,6 +882,54 @@
                 "volume"
             ],
             "type": "string"
+        },
+        "__type": {
+            "additionalProperties": false,
+            "properties": {
+                "addNames": {
+                    "enum": [
+                        "all",
+                        "all-with-initials",
+                        "by-cite",
+                        "primary",
+                        "primary-with-initials"
+                    ],
+                    "type": "string"
+                },
+                "addYearSuffix": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "addYearSuffix"
+            ],
+            "type": "object"
+        },
+        "__type_1": {
+            "additionalProperties": false,
+            "properties": {
+                "integral": {
+                    "$ref": "#/definitions/RefList",
+                    "description": "Integral citations are those where the author is printed inline in the text; aka \"in text\" or \"narrative\" citations."
+                }
+            },
+            "required": [
+                "integral"
+            ],
+            "type": "object"
+        },
+        "__type_2": {
+            "additionalProperties": false,
+            "properties": {
+                "nonIntegral": {
+                    "$ref": "#/definitions/RefList",
+                    "description": "Non-integral citations are those where the author is incorporated in the citation, and not printed inline in the text."
+                }
+            },
+            "required": [
+                "nonIntegral"
+            ],
+            "type": "object"
         }
     },
     "properties": {
@@ -875,6 +951,9 @@
         "description": {
             "description": "The description of the style.",
             "type": "string"
+        },
+        "disambiguation": {
+            "$ref": "#/definitions/Disambiguation"
         },
         "id": {
             "description": "The machine-readable token that uniquely identifies the style.",

--- a/src/style.ts
+++ b/src/style.ts
@@ -26,45 +26,24 @@ type ModeType =
   /**
    * @default "default"
    */
-  | "default"
-  | "narrative";
+  "default" | "narrative";
 
-type GroupSortType =
-  | "cs-author"
-  | "cs-year"
-  | "cs-author-year"
-  | "cs-as-cited";
+type GroupSortType = "cs-author" | "cs-year" | "cs-author-year" | "cs-as-cited";
 
-type CategoryType =
-  | "science"
-  | "social science"
-  | "biology";
+type CategoryType = "science" | "social science" | "biology";
 
 // extract, so can reuse elsewhere
-type RefType =
-  | "book"
-  | "article"
-  | "chapter";
+type RefType = "book" | "article" | "chapter";
 
-type ContributorType =
-  | "author"
-  | "editor"
-  | "publisher";
+type ContributorType = "author" | "editor" | "publisher";
 
 type DateType = "issued";
 
-type TitleType =
-  | "title"
-  | "container-title";
+type TitleType = "title" | "container-title";
 
-type LocatorType =
-  | "page"
-  | "chapter";
+type LocatorType = "page" | "chapter";
 
-type SimpleType =
-  | "volume"
-  | "issue"
-  | "pages";
+type SimpleType = "volume" | "issue" | "pages";
 
 // extract, so can reuse elsewhere
 type VariableType =
@@ -80,9 +59,7 @@ type MatchType =
    *
    * @default "all"
    */
-  | "all"
-  | "any"
-  | "none";
+  "all" | "any" | "none";
 
 // this is the structured template model
 type TemplateModel =
@@ -95,13 +72,9 @@ type TemplateModel =
   | Title
   | Cond;
 
-type GroupAffixType =
-  | "parentheses"
-  | "brackets";
+type GroupAffixType = "parentheses" | "brackets";
 
-type GroupAffixLevel =
-  | "primary"
-  | "secondary";
+type GroupAffixLevel = "primary" | "secondary";
 
 // eg liquid or mustache option for dev?
 type StringTemplate = string;
@@ -184,6 +157,16 @@ type DataTypeMatch =
   | Mode;
 type Condition = Match & DataTypeMatch;
 
+type Disambiguation = {
+  addYearSuffix: boolean;
+  addNames?:
+    | "all"
+    | "all-with-initials"
+    | "primary"
+    | "primary-with-initials"
+    | "by-cite";
+};
+
 // Style definition
 
 export interface Style {
@@ -203,6 +186,7 @@ export interface Style {
    * The categories the style belongs to; for purposes of indexing.
    */
   categories?: CategoryType[];
+  disambiguation?: Disambiguation;
   /**
    * The scope to use for localized terms.
    *
@@ -228,13 +212,12 @@ interface NamedTemplate {
    * The name token for the template, for reference from other templates.
    */
   name: string;
-  template:
-    /**
-     * The rendering instructions.
-     *
-     * @items.minimum 1
-     */
-    TemplateModel[]; // not converted to schema correctly
+  template: /**
+   * The rendering instructions.
+   *
+   * @items.minimum 1
+   */
+  TemplateModel[]; // not converted to schema correctly
 }
 
 interface RefItemTemplate extends HasFormatting {
@@ -293,10 +276,7 @@ interface RefListBlock extends RefList {
 // Not really sure here.
 
 // extract, to be used elsewhere
-type RoleType =
-  | "author"
-  | "editor"
-  | "publisher";
+type RoleType = "author" | "editor" | "publisher";
 
 // contributor modeling needs more thought in general
 // really need to be extracted
@@ -314,14 +294,14 @@ interface PersonalContributor extends Contributor {
 
 function formatContributor(
   contributor: PersonalContributor,
-  role?: string,
+  role?: string
 ): string {
   return `${contributor.familyName} ${contributor.givenName}`;
 }
 
 function formatContributorWithRole(
   contributor: Contributor,
-  role: string,
+  role: string
 ): string {
   return `${contributor.name} ${contributor.role}`;
 }


### PR DESCRIPTION
Add a `disambiguation` object property to `Style`, with the `Disambiguation` model an object derived from the model in CSL 1.0.

I thought maybe it would conflict with the explicit grouping logic in this experiment, but I think not.