### PR TITLE
docs: add svg uml diagrams to output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ node_modules:
 	npm install
 
 clean:
-	rm -rf dist
+	rm -rf dist docs 
 	
 docs:
-	npx typedoc src/style.ts src/citation.ts src/bibliography.ts src/reference.ts src/locator.ts
+	npx typedoc --plugin typedoc-umlclass  --tsconfig typedoc.json 
 
 json:
 	yq -P -o json '.' examples/style.csl.yaml > examples/style.csl.json

--- a/examples/csl-templates.yaml
+++ b/examples/csl-templates.yaml
@@ -15,6 +15,22 @@ templates:
                 # easily-localized parameters
                 affixes: quotes
         else:
-          - format:
-              - variable: title
-                emph: true
+          - variable: title
+            emph: true
+  - name: citation-chicago-author-date
+    template:
+      - delimiter: ", "
+      - when:
+          - hasVariable:
+              - issued
+            match: any
+            format:
+              - delimiter: " "
+                format:
+                  - template: contributors-short
+                  - template: date-in-text
+        else:
+          - delimiter: ", "
+            format:
+              - template: contributors-short
+              - template: date-in-text

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "edtf": "^4.4.1",
     "json-schema-edtf": "^1.0.3",
     "typedoc": "^0.24.6",
+    "typedoc-umlclass": "^0.7.1",
     "eslint": "^8.29.0",
     "ts-jest": "^29.0.3",
     "ts-loader": "^9.4.2",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,12 @@
+{
+  "entryPoints": [
+    "./src/citation.ts",
+    "./src/bibliography.ts",
+    "./src/style.ts",
+    "./src/locator.ts",
+    "./src/reference.ts"
+  ],
+  "umlClassDiagram": {
+    "arrowColor": "gray"
+  }
+}


### PR DESCRIPTION
The is easy to add; not sure if I want to though. Adds this sort of diagram to docs output.

![image](https://user-images.githubusercontent.com/1134/234096990-be629a10-887c-4138-b413-bd7d6ff28b1e.png)
