### PR TITLE
refactor(style): better normalize template model

### DIFF
--- a/src/reference.ts
+++ b/src/reference.ts
@@ -4,10 +4,20 @@ import { Contributor } from "./contributor";
 
 // Types
 
-// How to do this, so it translates to the schema correctly?
-//   1. define as literal string, OR EDTF date
-//   2. for the latter, use https://github.com/retorquere/json-schema-edtf
-export type CSLDate = string;
+/**
+ * A CSL date is an EDTF date; if not, it is a literal string.
+ */
+export type CSLDate = EDTFDATE | string;
+
+/**
+ * An EDTF level 0 or 1 date, with optional seasonal range.
+ * 
+ * See https://github.com/retorquere/json-schema-edtf
+ * 
+ * @format edtf/level-1+season-intervals
+ */
+export type EDTFDATE =
+  | string;
 
 export type ID = string; // string needs to be a token
 

--- a/src/style.ts
+++ b/src/style.ts
@@ -70,7 +70,7 @@ type MatchType =
   "all" | "any" | "none";
 
 // this is the structured template model
-type TemplateModel =
+export type TemplateModel =
   | RefList
   | RefItemTemplate
   | RefItemSimple
@@ -81,9 +81,9 @@ type TemplateModel =
   | Cond;
 
  
-type Template = CalledTemplate | InlineTemplate;  
-type CalledTemplate = string; // REVIEW can we make this more useful?
-type InlineTemplate = TemplateModel[];
+export type Template = CalledTemplate | InlineTemplate;  
+export type CalledTemplate = string; // REVIEW can we make this more useful?
+export type InlineTemplate = TemplateModel[];
 
 type AffixType = "parentheses" | "brackets" | "quotes";
 

--- a/src/style.ts
+++ b/src/style.ts
@@ -80,7 +80,10 @@ type TemplateModel =
   | Title
   | Cond;
 
+ 
+type Template = CalledTemplate | InlineTemplate;  
 type CalledTemplate = string; // REVIEW can we make this more useful?
+type InlineTemplate = TemplateModel[];
 
 type AffixType = "parentheses" | "brackets" | "quotes";
 
@@ -97,7 +100,7 @@ interface Cond {
   /**
    * When all of the when conditions are nil, format the children.
    */
-  else?: TemplateModel[];
+  else?: InlineTemplate; // REVIEW
 }
 
 type Match = {
@@ -110,7 +113,7 @@ type Match = {
   /**
    * When a match, process these templates.
    */
-  format: TemplateModel[];
+  format: InlineTemplate; // REVIEW
 };
 
 type IsNumber = {
@@ -272,7 +275,7 @@ export interface NamedTemplate {
    *
    * @items.minimum 1
    */
-  TemplateModel[]; // not converted to schema correctly
+  InlineTemplate; // REVIEW
 }
 
 interface RefItemTemplate extends HasFormatting {
@@ -287,7 +290,7 @@ export interface RefList extends HasFormatting {
   /** 
    * The rendering instructions; either called template name, or inline instructions.
    */
-  format: CalledTemplate | TemplateModel[];
+  format: CalledTemplate | InlineTemplate;
 }
 
 interface RefListBlock extends RefList {

--- a/src/style.ts
+++ b/src/style.ts
@@ -178,13 +178,29 @@ type SubstitutionType =
    | "title"
    ;
 
-// OptionGroup
-
+/**
+ * Parameter groups.
+ */
 export interface OptionGroup {
+  /**
+   * Sorting configuration.
+   */
   sort?: Sort[];
+  /**
+   * Grouping configuration.
+   */ 
   group?: Group[];
+  /**
+   * Substitution configuration.
+   */
   substitute?: Substitution;
+  /**
+   * Disambiguation configuration.
+   */
   disambiguate?: Disambiguation;
+  /**
+   * Localization configuration.
+   */
   localization?: Localization;
 
 }
@@ -227,7 +243,8 @@ export interface Disambiguation {
 
 export interface Substitution {
   /**
-   * The token to substitute.
+   * When author is nil, substitute the first non-nil listed variable. 
+   * Once a substitution is made, the substituted variable shall be set to nil for purposes of later rendering.
    * 
    * @default ["editor", "translator", "title"]
    * 

--- a/src/style.ts
+++ b/src/style.ts
@@ -80,9 +80,19 @@ export type TemplateModel =
   | Title
   | Cond;
 
- 
-export type Template = CalledTemplate | InlineTemplate;  
+/**
+ * The rendering of style templates can be specified by reference to a template name or by inline definition.
+ */
+export type Template = CalledTemplate | InlineTemplate;
+
+/**
+ * A template is called by name.
+ */
 export type CalledTemplate = string; // REVIEW can we make this more useful?
+
+/**
+ * A template that is defined inline.
+ */
 export type InlineTemplate = TemplateModel[];
 
 type AffixType = "parentheses" | "brackets" | "quotes";


### PR DESCRIPTION
Need to normalize the basic template model technically and conceptually.

The issue I'm currently unsure of is how best to handle the properties that use the template types. Edit: I think I'll defer this.

Also working on a few other minor issues on this branch:

- #4
- JSDoc docs
- export more types, so `typedoc` works better

Close: #38 