### PR TITLE
feat(processor): add class transforms

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,17 @@
+import "reflect-metadata";
 import { Bibliography } from "./bibliography";
+import { Reference } from "./reference";
 import { loadJSON, loadYAML } from "./utils";
+import { plainToClass } from "class-transformer";
 
 const bibj = loadJSON("examples/bibliography.json");
-const biby = loadYAML("examples/bibliography.yaml"); // why error?
+const biby = loadYAML("examples/bibliography.yaml");
 
-console.log("The JSON bibliography is:\n", bibj);
+const bibjts = plainToClass(Bibliography, bibj);
+const bibyts = plainToClass(Bibliography, biby);
 
-console.log("The YAML bibliography converted to JS is:\n", biby);
+console.log("The JSON bibliography is:\n", bibjts);
+
+console.log("The YAML bibliography converted to JS is:\n", bibyts);
 
 console.log("The rest is ... TODO!");

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,5 +1,6 @@
 // Typescript model for a CSL Reference
 
+import { Type } from "class-transformer";
 import { Contributor } from "./contributor";
 
 // Types
@@ -40,6 +41,8 @@ export class Reference {
 	id: ID;
 	type: ReferenceType;
 	title: Title;
+
+	// @Type(() => Person) // should work, but does not
 	author?: Contributor[];
 	editor?: Contributor[];
 	publisher?: Contributor[];
@@ -51,5 +54,11 @@ export class Reference {
 		this.id = id;
 		this.type = type;
 		this.title = title;
+		this.author = [];
+		this.editor = [];
+		this.publisher = [];
+		this.issued = "";
+		this.abstract = "";
+		this.accessed = "";
 	}
 }


### PR DESCRIPTION
So `plainToClass` works as expected here, on both `Reference` and `Bibliography`, with  `JSON` input or `YAML`.

```js
The YAML bibliography converted to JS is:
 Bibliography {
  title: 'My Bibliography',
  description: 'A collection of references.',
  references: [
    Reference {
      id: 'doe1',
      type: 'book',
      title: 'The Title',
      author: [Array],
      editor: [],
      publisher: [],
      issued: '2023',
      abstract: '',
      accessed: ''
    }
```

But the `@Type` decorator does not; it errors. 

I've commented it out for now, and may just merge as is, and address that later.