### PR TITLE
feat(processor): add nested decorators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean:
 	rm -rf dist docs 
 	
 docs:
-	npx typedoc --plugin typedoc-umlclass  --tsconfig typedoc.json 
+	npx typedoc --plugin typedoc-umlclass 
 
 json:
 	yq -P -o json '.' examples/style.csl.yaml > examples/style.csl.json

--- a/src/bibliography.ts
+++ b/src/bibliography.ts
@@ -1,6 +1,6 @@
-import "reflect-metadata";
-//import { Type } from "class-transformer";
 import { Reference, ID } from "./reference";
+import { Type, plainToClass } from "class-transformer";
+import "reflect-metadata";
 
 /**
  * A bibliography is a collection of references.
@@ -42,7 +42,8 @@ export class Bibliography {
 	 *
 	 * @items.minimum 1
 	 */
-	// @Type(() => Reference) // FIX getting an area; seems a bug elsewhere
+
+	@Type(() => Reference) // FIX getting an error; seems a bug elsewhere
 	references: Reference[];
 
 	constructor(title?: string, description?: string) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,5 +13,5 @@ const bibyts = plainToClass(Bibliography, biby);
 console.log("The JSON bibliography is:\n", bibjts);
 
 console.log("The YAML bibliography converted to JS is:\n", bibyts);
-
+console.log("A nested contributor:\n", bibyts.references[0].author);
 console.log("The rest is ... TODO!");

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,5 +13,5 @@ const bibyts = plainToClass(Bibliography, biby);
 console.log("The JSON bibliography is:\n", bibjts);
 
 console.log("The YAML bibliography converted to JS is:\n", bibyts);
-console.log("A nested contributor:\n", bibyts.references[0].author);
+console.log("A nested contributor:\n", bibyts.references[4].author);
 console.log("The rest is ... TODO!");

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,7 +1,8 @@
 // Typescript model for a CSL Reference
 
-//import { Type } from "class-transformer";
-import { Contributor } from "./contributor";
+import { Type } from "class-transformer";
+import "reflect-metadata";
+import { Contributor, Person } from "./contributor";
 
 // Types
 
@@ -42,8 +43,8 @@ export class Reference {
 	type: ReferenceType;
 	title: Title;
 
-	// @Type(() => Person) // should work, but does not
-	author?: Contributor[];
+	@Type(() => Person) // should work, but does not
+	author?: Person[];
 	editor?: Contributor[];
 	publisher?: Contributor[];
 	issued?: CSLDate;

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -2,7 +2,7 @@
 
 import { Type } from "class-transformer";
 import "reflect-metadata";
-import { Contributor, Person } from "./contributor";
+import { Contributor, Organization, Person } from "./contributor";
 
 // Types
 
@@ -43,8 +43,15 @@ export class Reference {
 	type: ReferenceType;
 	title: Title;
 
-	@Type(() => Person) // should work, but does not
-	author?: Person[];
+	@Type(() => Contributor, {
+    discriminator: {
+      property: 'type',
+      subTypes: [
+        { value: Person, name: 'person' },
+        { value: Organization, name: 'organization' },  ],
+    },
+  })
+	author?: (Person | Organization)[];
 	editor?: Contributor[];
 	publisher?: Contributor[];
 	issued?: CSLDate;


### PR DESCRIPTION
Fix a bug in the Makefile, and add `@Type` decorators for nested arrays.

This works, but requires a `type` property on the contributor JSON to discriminate between the two subclasses.

Am thinking of changing to a single `Contributor` class, but that brings other issues.