### PR TITLE
rename: affixes -> wrap, remove prefix/suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The code here is a `typescript` project that:
 
 The first is maybe 70% or so complete, while the second is barely-started.
 
-Here is`VSCode`, with schema-backed validation of a YAML style, auto-complete.
+Here is`VSCode`, with schema-backed validation and auto-completion of a YAML style.
 
 ![Screenshot from 2023-04-16 10-22-25](https://user-images.githubusercontent.com/1134/232319672-88e96d95-1806-4d6b-9d27-6d0cc32d5033.png)
 
@@ -72,7 +72,7 @@ Possibilities:
 2. I _hate_ hand authoring `JSON schema`, even in `YAML`.
 3. It's widely supported in the `JS` world, and `JS` widely supported more generally.
 4. Because the [djot](https://djot.net/) reference implementation uses it, I'd like to take advantage of that.
-5. There are two good `EDTF` libraries for date validation and formatting.
+5. There are two good `EDTF` JavaScript libraries for date validation and formatting.
 6. It might be possible to incorporate some code from [citeproc-js](https://github.com/Juris-M/citeproc-js)?
 
 ### Why `JSON Schema`? What happened to `XML`?

--- a/examples/csl-templates.yaml
+++ b/examples/csl-templates.yaml
@@ -1,8 +1,14 @@
-# yaml-language-server: $schema=/home/bruce/Code/csl-next.js/schemas/csl-template-file.json 
+# yaml-language-server: $schema=../schemas/csl-style-schema.json
 ---
 title: Example template file
 description: This is an example of how we might bundle together widely used partial templates.
 templates:
+  - name: how-publisher-apa
+    template:
+      - wrap: parentheses
+        delimiter: ", "
+        format: 
+          - variable: publisher
   - name: title-apa
     template:
       - when:
@@ -13,7 +19,7 @@ templates:
               - variable: title
                 # instead of using prefix and suffix strings for punctation, let's use
                 # easily-localized parameters
-                affixes: quotes
+                wrap: quotes
         else:
           - variable: title
             emph: true

--- a/examples/style.csl.yaml
+++ b/examples/style.csl.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=/home/bruce/Code/csl-next.js/schemas/csl-style-schema.json 
+# yaml-language-server: $schema=/home/bruce/Code/csl-next.js/schemas/csl-style-schema.json
 ---
 # this is a flatter model, relying more heavily on parameters
 title: APA
@@ -21,8 +21,6 @@ options:
   group:
     # be explicit about grouping, which is core logic
     - key: author
-      # not sure on details here yet, but basic idea is disambiguation 
-      # is related to grouping
     - key: year
   # pave the way for multilingual support
   localization:
@@ -37,35 +35,35 @@ citation:
   options:
     # There's only so many ways to sort and group, so let's just itemize them
     sort:
-     - key: author
-       order: ascending
-     - key: year
-       order: descending  # in CSL 1.0, we have this global, but it's specific to citations
+      - key: author
+        order: ascending
+      - key: year
+        order: descending # in CSL 1.0, we have this global, but it's specific to citations
     group:
       - key: author
-        # again: another example where there are only a few options
-        affixes: parentheses # maybe would need localizing though? 
-        delimiter: semicolon
       - key: year
   integral:
     options:
       group:
         - key: author
-          affixes: parentheses # REVIEW
-  format:
-    # in this example, no need for conditional here
-    # configure delimiters in parameters
-    # author-date styles are such a hassle at this level!
-    - template: author-apa
-    - template: year
-    - template: locators-apa
+    format:
+      - template: author-apa
+      - wrap: parentheses
+        format:
+          - template: year
+          - template: locators-apa
+  nonIntegral:
+    format:
+      - wrap: parentheses
+        delimiter: ": "
+        format:
+          - template: year
+          - template: locators-apa
 bibliography:
   format:
     - template: author-apa-full
     - template: year
-      affixes: parentheses
-      suffix: " " # REVIEW must this be a string?
+      wrap: parentheses
     - template: title
-      suffix: comma
     - template: container-apa
     - template: howpublished-apa

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "node ./build/esbuild.js --dev",
+    "build": "node ./build/esbuild.cjs --dev",
     "build:meta": "node ./build/esbuild.js --dev --meta",
     "build:meta:prod": "node ./build/esbuild.cjs --meta",
     "build:prod": "node ./build/esbuild.cjs",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "typescript-json-schema": "^0.56.0"
   },
   "dependencies": {
+    "ajv": "^8.12.0",
     "edtf": "^4.4.1",
     "yaml": "^2.2.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,9 @@
 lockfileVersion: '6.0'
 
 dependencies:
+  ajv:
+    specifier: ^8.12.0
+    version: 8.12.0
   edtf:
     specifier: ^4.4.1
     version: 4.4.1
@@ -420,6 +423,15 @@ packages:
     hasBin: true
     dev: true
 
+  /ajv@8.12.0:
+    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+    dev: false
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -592,6 +604,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: false
+
   /foreground-child@3.1.1:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
@@ -681,6 +697,10 @@ packages:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
     dev: true
+
+  /json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    dev: false
 
   /jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
@@ -794,6 +814,11 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
+  /punycode@2.3.0:
+    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
+    engines: {node: '>=6'}
+    dev: false
+
   /queue-fifo@0.2.6:
     resolution: {integrity: sha512-rwlnZHAaTmWEGKC7ziasK8u4QnZW/uN6kSiG+tHNf/1GA+R32FArZi18s3SYUpKcA0Y6jJoUDn5GT3Anoc2mWw==}
     dependencies:
@@ -842,6 +867,11 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /ret@0.1.15:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
@@ -1052,6 +1082,12 @@ packages:
     engines: {node: '>=12.20'}
     hasBin: true
     dev: true
+
+  /uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    dependencies:
+      punycode: 2.3.0
+    dev: false
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}

--- a/src/style.ts
+++ b/src/style.ts
@@ -170,7 +170,7 @@ export interface OptionGroup {
 	/**
 	 * Grouping configuration.
 	 */
-	group?: Group[];
+	group?: GroupSortType[];
 	/**
 	 * Substitution configuration.
 	 */

--- a/src/style.ts
+++ b/src/style.ts
@@ -228,7 +228,14 @@ export interface Sort extends SortGroup {
  * Reference grouping of configuration.
  */
 export interface Group extends SortGroup {
+	/**
+	 * The symbol pair to wrap around one or more rendering components.
+	 * Interaction with surrounding punctuation is localized.
+	 */
 	wrap?: WrapType;
+	/**
+	 * The string with which to join two or more rendering comnponents.
+	 */
 	delimiter?: string;
 }
 

--- a/src/style.ts
+++ b/src/style.ts
@@ -18,9 +18,9 @@ export interface HasFormatting {
 	 */
 	suffix?: string;
 	/**
-	 * What to surround the content with.
+	 * The punctuation to wrap the content with.
 	 */
-	affixes?: AffixType; // REVIEW
+	wrap?: WrapType;
 	bold?: boolean;
 	emph?: boolean;
 }
@@ -94,7 +94,7 @@ export type CalledTemplate = string; // REVIEW can we make this more useful?
  */
 export type InlineTemplate = TemplateModel[];
 
-type AffixType = "parentheses" | "brackets" | "quotes";
+type WrapType = "parentheses" | "brackets" | "quotes";
 
 // eg liquid or mustache option for dev?
 //type StringTemplate = string;
@@ -228,7 +228,7 @@ export interface Sort extends SortGroup {
  * Reference grouping of configuration.
  */
 export interface Group extends SortGroup {
-	affixes?: AffixType;
+	wrap?: WrapType;
 	delimiter?: string;
 }
 

--- a/src/style.ts
+++ b/src/style.ts
@@ -8,17 +8,11 @@ export interface TemplateFile {
 	templates: NamedTemplate[];
 }
 
+type WrapType = "parentheses" | "brackets" | "quotes";
 export interface HasFormatting {
 	/**
-	 * The string to insert before the content.
-	 */
-	prefix?: string;
-	/**
-	 * The string to insert after the content.
-	 */
-	suffix?: string;
-	/**
-	 * The punctuation to wrap the content with.
+	 * The symbol pair to wrap around one or more rendering components.
+	 * Interaction with surrounding punctuation is localized.
 	 */
 	wrap?: WrapType;
 	bold?: boolean;
@@ -73,10 +67,10 @@ export type TemplateModel =
 	| RenderList
 	| RenderItemTemplate
 	| RenderItemSimple
-	| Contributors
-	| Locators
+	| RenderContributors
+	| RenderLocators
 	| RenderItemDate
-	| Title
+	| RenderTitle
 	| Cond;
 
 /**
@@ -93,8 +87,6 @@ export type CalledTemplate = string; // REVIEW can we make this more useful?
  * A template that is defined inline.
  */
 export type InlineTemplate = TemplateModel[];
-
-type WrapType = "parentheses" | "brackets" | "quotes";
 
 // eg liquid or mustache option for dev?
 //type StringTemplate = string;
@@ -228,11 +220,6 @@ export interface Sort extends SortGroup {
  * Reference grouping of configuration.
  */
 export interface Group extends SortGroup {
-	/**
-	 * The symbol pair to wrap around one or more rendering components.
-	 * Interaction with surrounding punctuation is localized.
-	 */
-	wrap?: WrapType;
 	/**
 	 * The string with which to join two or more rendering comnponents.
 	 */
@@ -377,9 +364,13 @@ interface RenderItemTemplate extends HasFormatting {
 export interface RenderList extends HasFormatting {
 	options?: OptionGroup;
 	/**
+	 * The string with which to join two or more rendering comnponents.
+	 */
+	delimiter?: string;
+	/**
 	 * The rendering instructions; either called template name, or inline instructions.
 	 */
-	format: CalledTemplate | InlineTemplate;
+	format?: CalledTemplate | InlineTemplate;
 }
 
 interface RenderListBlock extends RenderList {
@@ -397,17 +388,17 @@ interface RenderItemDate extends HasFormatting {
 	format?(date: string): string;
 }
 
-interface Title extends HasFormatting {
-	variable: TitleType;
-	main(title: string): string;
+interface RenderTitle extends HasFormatting {
+	variable: TitleType; // REVIEW title instead?
+	main(title: string): string; // REVIEW
 	sub(title: string): string;
 }
 
-interface Contributors extends RenderList {
+interface RenderContributors extends RenderList {
 	variable: ContributorType;
 }
 
-interface Locators extends RenderList {
+interface RenderLocators extends RenderList {
 	variable: LocatorType;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "lib",
     "experimentalDecorators": true,
     "allowImportingTsExtensions": true,
+    "noEmit": true,
     "noUnusedLocals": false,
     "removeComments": true,
     "strict": true,


### PR DESCRIPTION
Remove `prefix` and `suffix` in favor of `delimiter` and `wrap`.

With that change, I need to think a bit about the model.

Currently there is basically item, group, list, and those two properties are duplicated in more than one place.

Maybe can and should simplify that? 

Even if not, need to fix something in that modeling, to avoid duplication.