### PR TITLE
refactor(bibliography): make references an object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 types
-build
 dist
 schemas
 lib

--- a/build/esbuild.cjs
+++ b/build/esbuild.cjs
@@ -4,51 +4,51 @@ const esbuild = require("esbuild");
 
 /** @type esbuild.BuildOptions */
 const devConfig = {
-  sourcemap: "linked",
+	sourcemap: "linked",
 };
 
 /** @type esbuild.BuildOptions */
 const prodConfig = {
-  minify: true,
+	minify: true,
 };
 
 /** @type esbuild.BuildOptions */
 const config = {
-  entryPoints: ["src/main.ts"],
-  outfile: "dist/main.cjs",
-  bundle: true,
-  platform: "node",
-  logLevel: "info",
+	entryPoints: ["src/main.ts"],
+	outfile: "dist/main.cjs",
+	bundle: true,
+	platform: "node",
+	logLevel: "info",
 
-  define: {
-    VERSION: JSON.stringify(process.env.npm_package_version),
-    DEVELOP: JSON.stringify(!!argv.dev),
-  },
+	define: {
+		VERSION: JSON.stringify(process.env.npm_package_version),
+		DEVELOP: JSON.stringify(!!argv.dev),
+	},
 
-  plugins: [],
+	plugins: [],
 
-  metafile: argv.meta,
-  ...(argv.dev ? devConfig : prodConfig),
+	metafile: argv.meta,
+	...(argv.dev ? devConfig : prodConfig),
 };
 
 if (argv.run)
-  config.plugins.push(
-    require("@es-exec/esbuild-plugin-start").default({
-      script: "node dist/main.cjs",
-    }),
-  );
+	config.plugins.push(
+		require("@es-exec/esbuild-plugin-start").default({
+			script: "node dist/main.cjs",
+		}),
+	);
 
 if (argv.watch) {
-  (async () => {
-    const ctx = await esbuild.context(config);
-    await ctx.watch();
-  })();
+	(async () => {
+		const ctx = await esbuild.context(config);
+		await ctx.watch();
+	})();
 } else {
-  esbuild.build(config).then((file) => {
-    if (argv.meta)
-      require("fs").writeFileSync(
-        "dist/meta.json",
-        JSON.stringify(file.metafile),
-      );
-  });
+	esbuild.build(config).then((file) => {
+		if (argv.meta)
+			require("fs").writeFileSync(
+				"dist/meta.json",
+				JSON.stringify(file.metafile),
+			);
+	});
 }

--- a/build/esbuild.cjs
+++ b/build/esbuild.cjs
@@ -4,51 +4,51 @@ const esbuild = require("esbuild");
 
 /** @type esbuild.BuildOptions */
 const devConfig = {
-	sourcemap: "linked",
+  sourcemap: "linked",
 };
 
 /** @type esbuild.BuildOptions */
 const prodConfig = {
-	minify: true,
+  minify: true,
 };
 
 /** @type esbuild.BuildOptions */
 const config = {
-	entryPoints: ["src/main.ts"],
-	outfile: "dist/main.js",
-	bundle: true,
-	platform: "node",
-	logLevel: "info",
+  entryPoints: ["src/main.ts"],
+  outfile: "dist/main.cjs",
+  bundle: true,
+  platform: "node",
+  logLevel: "info",
 
-	define: {
-		VERSION: JSON.stringify(process.env.npm_package_version),
-		DEVELOP: JSON.stringify(!!argv.dev),
-	},
+  define: {
+    VERSION: JSON.stringify(process.env.npm_package_version),
+    DEVELOP: JSON.stringify(!!argv.dev),
+  },
 
-	plugins: [],
+  plugins: [],
 
-	metafile: argv.meta,
-	...(argv.dev ? devConfig : prodConfig),
+  metafile: argv.meta,
+  ...(argv.dev ? devConfig : prodConfig),
 };
 
 if (argv.run)
-	config.plugins.push(
-		require("@es-exec/esbuild-plugin-start").default({
-			script: "node dist/main.js",
-		}),
-	);
+  config.plugins.push(
+    require("@es-exec/esbuild-plugin-start").default({
+      script: "node dist/main.cjs",
+    }),
+  );
 
 if (argv.watch) {
-	(async () => {
-		const ctx = await esbuild.context(config);
-		await ctx.watch();
-	})();
+  (async () => {
+    const ctx = await esbuild.context(config);
+    await ctx.watch();
+  })();
 } else {
-	esbuild.build(config).then((file) => {
-		if (argv.meta)
-			require("fs").writeFileSync(
-				"dist/meta.json",
-				JSON.stringify(file.metafile),
-			);
-	});
+  esbuild.build(config).then((file) => {
+    if (argv.meta)
+      require("fs").writeFileSync(
+        "dist/meta.json",
+        JSON.stringify(file.metafile),
+      );
+  });
 }

--- a/examples/bibliography.yaml
+++ b/examples/bibliography.yaml
@@ -1,44 +1,41 @@
-title: My Bibliography
-description: A collection of references.
-references:
-  doc1: 
-    id: doe1
-    type: book
-    title: The Title
-    author:
-      - familyName: Doe
-        givenName: Jane
-    issued: "2023"
-  smith1:
-    id: smith1
-    type: book
-    title: The Title
-    author:
-      - familyName: Smith
-        givenName: Sam
-    issued: "2023"
-  doe2:
-    id: doe2
-    type: book
-    title: The Title
-    author:
-      - familyName: Doe
-        givenName: Jane
-    issued: "2023"
-  doe3:
-    id: doe3
-    type: article
-    title: The Title
-    author:
-      - type: person
-        familyName: Doe
-        givenName: Jane
-    issued: "2022"
-  un:
-    id: un
-    type: article
-    title: The Title
-    author:
-      - type: organization
-        name: United Nations
-    issued: "2020"
+doc1:
+  id: doe1
+  type: book
+  title: The Title
+  author:
+    - name: Doe, Jane
+  issued: '2023'
+smith1:
+  id: smith1
+  type: book
+  title: The Title
+  author:
+    - name: Smith, Sam
+  issued: '2023'
+doe2:
+  id: doe2
+  type: book
+  title: The Title
+  author:
+    - name: Doe, Jane
+  issued: '2023'
+doe3:
+  id: doe3
+  type: article
+  title: The Title
+  author:
+    - name: Doe, Jane
+  issued: '2022'
+un:
+  id: un
+  type: article
+  title: The Title
+  author:
+    - name: United Nations
+      parse: falase
+  issued: '2020'
+
+
+
+
+

--- a/examples/bibliography.yaml
+++ b/examples/bibliography.yaml
@@ -1,28 +1,32 @@
 title: My Bibliography
 description: A collection of references.
 references:
-  - id: doe1
+  doc1: 
+    id: doe1
     type: book
     title: The Title
     author:
       - familyName: Doe
         givenName: Jane
     issued: "2023"
-  - id: smith1
+  smith1:
+    id: smith1
     type: book
     title: The Title
     author:
       - familyName: Smith
         givenName: Sam
     issued: "2023"
-  - id: doe2
+  doe2:
+    id: doe2
     type: book
     title: The Title
     author:
       - familyName: Doe
         givenName: Jane
     issued: "2023"
-  - id: doe3
+  doe3:
+    id: doe3
     type: article
     title: The Title
     author:
@@ -30,7 +34,8 @@ references:
         familyName: Doe
         givenName: Jane
     issued: "2022"
-  - id: un
+  un:
+    id: un
     type: article
     title: The Title
     author:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "node ./build/esbuild.cjs --dev",
-    "build:meta": "node ./build/esbuild.js --dev --meta",
+    "build:meta": "node ./build/esbuild.cjs --dev --meta",
     "build:meta:prod": "node ./build/esbuild.cjs --meta",
     "build:prod": "node ./build/esbuild.cjs",
     "lint": "rome check ./src/**.ts",

--- a/src/bibliography.ts
+++ b/src/bibliography.ts
@@ -1,4 +1,4 @@
-import { Reference, ID } from "./reference";
+import { ID, IDReference, Reference } from "./reference";
 import { Type, plainToClass } from "class-transformer";
 import "reflect-metadata";
 
@@ -14,6 +14,14 @@ import "reflect-metadata";
  */
 export class Bibliography {
 	/**
+	 * The references object..
+	 *
+	 * @items.minimum 1
+	 */
+	// TODO get this working with class-transformer
+	// @Type(() => IDReference) // TODO causes and error
+	references: IDReference;
+	/**
 	 * The title of the bibliography.
 	 */
 	title?: string;
@@ -22,33 +30,13 @@ export class Bibliography {
 	 */
 	description?: string;
 
-	/**
-	 * The references array.
-	 *
-	 * @items.minimum 1
-	 */
-	// TODO get this working with class-transformer
-	//@Type(() => Reference) // FIX getting an error; seems a bug elsewhere
-	// https://stackoverflow.com/a/65206867/13860420
-	references: Record<string, Reference>;
-
 	constructor(
 		references: Record<string, Reference>,
 		title?: string,
 		description?: string,
 	) {
+		this.references = references;
 		this.title = title;
 		this.description = description;
-		this.references = references;
-	}
-
-	// addReference(reference: Reference): void {
-	// 	this.references.push(reference);
-	// }
-
-	getReference(id: ID, references: Reference[]): Reference[] {
-		// FIX why doesn't this work?
-		// return references.find((ref as Reference) => ref.id as ID === id);
-		return references;
 	}
 }

--- a/src/bibliography.ts
+++ b/src/bibliography.ts
@@ -1,40 +1,13 @@
-import { IDReference, Reference } from "./reference";
-import { Type, plainToClass } from "class-transformer";
+import { Reference } from "./reference";
 import "reflect-metadata";
+import { plainToClass } from "class-transformer";
 
 type BibliographyFile = string; // is there a path type I can use?
 
-/**
- * A bibliography is a collection of references.
- *
- * It is the input of a citation processor.
- *
- * @examples
- * {
- * "title": "My Bibliography",
- * "description": "A collection of references.",
- */
-export class Bibliography {
-	/**
-	 * The references object..
-	 *
-	 * @items.minimum 1
-	 */
-	// TODO get this working with class-transformer
-	//@Type(() => IDReference) // TODO this confusing error
-	references: IDReference;
-	/**
-	 * The title of the bibliography.
-	 */
-	title?: string;
-	/**
-	 * The description of the bibliography.
-	 */
-	description?: string;
+interface IInputBibliography {
+	[key: string]: Reference;
+}
 
-	constructor(references: IDReference, title?: string, description?: string) {
-		this.references = references;
-		this.title = title;
-		this.description = description;
-	}
+export class InputBibliography implements IInputBibliography {
+	[key: string]: Reference;
 }

--- a/src/bibliography.ts
+++ b/src/bibliography.ts
@@ -42,19 +42,24 @@ export class Bibliography {
 	 *
 	 * @items.minimum 1
 	 */
+	// TODO get this working with class-transformer
+	//@Type(() => Reference) // FIX getting an error; seems a bug elsewhere
+	// https://stackoverflow.com/a/65206867/13860420
+	references: Record<string, Reference>;
 
-	@Type(() => Reference) // FIX getting an error; seems a bug elsewhere
-	references: Reference[];
-
-	constructor(title?: string, description?: string) {
+	constructor(
+		references: Record<string, Reference>,
+		title?: string,
+		description?: string,
+	) {
 		this.title = title;
 		this.description = description;
-		this.references = [];
+		this.references = references;
 	}
 
-	addReference(reference: Reference): void {
-		this.references.push(reference);
-	}
+	// addReference(reference: Reference): void {
+	// 	this.references.push(reference);
+	// }
 
 	getReference(id: ID, references: Reference[]): Reference[] {
 		// FIX why doesn't this work?

--- a/src/bibliography.ts
+++ b/src/bibliography.ts
@@ -11,21 +11,6 @@ import "reflect-metadata";
  * {
  * "title": "My Bibliography",
  * "description": "A collection of references.",
- * "references": [
- *   {
- *     "id": "doe1",
- *     "type": "book",
- *    "title": "The Title",
- *     "author": [
- *       {
- *         "family": "Doe",
- *         "given": "Jane"
- *       }
- *     ],
- *     "issued": "2023"
- *   }
- * ]
- *}
  */
 export class Bibliography {
 	/**

--- a/src/bibliography.ts
+++ b/src/bibliography.ts
@@ -1,6 +1,8 @@
-import { ID, IDReference, Reference } from "./reference";
+import { IDReference, Reference } from "./reference";
 import { Type, plainToClass } from "class-transformer";
 import "reflect-metadata";
+
+type BibliographyFile = string; // is there a path type I can use?
 
 /**
  * A bibliography is a collection of references.
@@ -19,7 +21,7 @@ export class Bibliography {
 	 * @items.minimum 1
 	 */
 	// TODO get this working with class-transformer
-	// @Type(() => IDReference) // TODO causes and error
+	//@Type(() => IDReference) // TODO this confusing error
 	references: IDReference;
 	/**
 	 * The title of the bibliography.
@@ -30,11 +32,7 @@ export class Bibliography {
 	 */
 	description?: string;
 
-	constructor(
-		references: Record<string, Reference>,
-		title?: string,
-		description?: string,
-	) {
+	constructor(references: IDReference, title?: string, description?: string) {
 		this.references = references;
 		this.title = title;
 		this.description = description;

--- a/src/contributor.ts
+++ b/src/contributor.ts
@@ -1,49 +1,14 @@
 // contributor modeling needs more thought in general
 
-export abstract class Contributor {
-	name: string;
-
-	constructor(name: string) {
+// keep this simple for now
+export class Contributor {
+	constructor(
+		public name: string,
+		public role: string = "author",
+		public parse: boolean = true,
+	) {
 		this.name = name;
-	}
-
-	display(): string {
-		return this.name;
-	}
-}
-
-export class Organization extends Contributor {
-	name: string;
-	location?: string;
-
-	constructor(name: string, location?: string) {
-		super(name);
-		this.name = name;
-		this.location = location;
-	}
-
-	sortName(): string {
-		return this.name;
-	}
-}
-
-export class Person extends Contributor {
-	name: string;
-	familyName: string;
-	givenName: string;
-
-	constructor(name: string, givenName: string, familyName: string) {
-		super(name);
-		this.name = name;
-		this.givenName = givenName;
-		this.familyName = familyName;
-	}
-
-	displayName(initialize: boolean): string {
-		return `${this.givenName} ${this.familyName}`;
-	}
-
-	sortName(): string {
-		return `${this.familyName}, ${this.givenName}`;
+		this.role = role;
+		this.parse = parse;
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,5 +13,5 @@ const bibyts = plainToClass(Bibliography, biby);
 console.log("The JSON bibliography is:\n", bibjts);
 
 console.log("The YAML bibliography converted to JS is:\n", bibyts);
-console.log("A nested contributor:\n", bibyts.references.doe1.author);
+console.log("A nested contributor:\n", bibyts.references.un.author);
 console.log("The rest is ... TODO!");

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,7 @@
 import "reflect-metadata";
 import { Bibliography } from "./bibliography";
+import { Style } from "./style";
+import { Processor } from "./processor";
 //import { Reference } from "./reference";
 import { loadJSON, loadYAML } from "./utils";
 import { plainToClass } from "class-transformer";
@@ -7,11 +9,12 @@ import { plainToClass } from "class-transformer";
 const bibj = loadJSON("examples/bibliography.json");
 const biby = loadYAML("examples/bibliography.yaml");
 
+const csly = loadYAML("examples/style.csl.yaml");
+
 const bibjts = plainToClass(Bibliography, bibj);
 const bibyts = plainToClass(Bibliography, biby);
 
-console.log("The JSON bibliography is:\n", bibjts);
+const CiteProc = new Processor(csly, bibyts);
 
-console.log("The YAML bibliography converted to JS is:\n", bibyts);
-console.log("A nested contributor:\n", bibyts.references.un.author);
-console.log("The rest is ... TODO!");
+console.log(CiteProc.getReferences());
+console.log(CiteProc.getReferences()[4].author);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,20 +1,17 @@
-import "reflect-metadata";
-import { Bibliography } from "./bibliography";
+import { InputBibliography } from "./bibliography";
 import { Style } from "./style";
 import { Processor } from "./processor";
 //import { Reference } from "./reference";
 import { loadJSON, loadYAML } from "./utils";
-import { plainToClass } from "class-transformer";
 
 const bibj = loadJSON("examples/bibliography.json");
 const biby = loadYAML("examples/bibliography.yaml");
 
 const csly = loadYAML("examples/style.csl.yaml");
 
-const bibjts = plainToClass(Bibliography, bibj);
-const bibyts = plainToClass(Bibliography, biby);
+const CiteProc = new Processor(csly, biby);
+const refs = CiteProc.getProcReferences();
 
-const CiteProc = new Processor(csly, bibyts);
-
-console.log(CiteProc.getReferences());
-console.log(CiteProc.getReferences()[4].author);
+console.log(CiteProc);
+console.log(CiteProc.getProcReferences());
+console.log(refs[2].formatAuthors());

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,5 +13,5 @@ const bibyts = plainToClass(Bibliography, biby);
 console.log("The JSON bibliography is:\n", bibjts);
 
 console.log("The YAML bibliography converted to JS is:\n", bibyts);
-console.log("A nested contributor:\n", bibyts.references[4].author);
+console.log("A nested contributor:\n", bibyts.references.doe1.author);
 console.log("The rest is ... TODO!");

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -2,27 +2,23 @@ import { Style, SortType, GroupSortType } from "./style";
 import { Reference, ID } from "./reference";
 import { CiteRef } from "./citation";
 import { Bibliography } from "./bibliography";
-import { plainToClass } from "class-transformer";
+import { Type, plainToClass } from "class-transformer";
 import "reflect-metadata";
 
 export class Processor {
 	style: Style;
-	citeRefs: CiteRef[];
+	//citeRefs: CiteRef[];
 	bibliography: Bibliography;
-	// convert to array, and then to class instances
-	// TODO this seems to work, but linter is saying it shouldn't
-	//   also, this should only load from the CiteKeys in the CiteRefs
-	private _references: plainToClass(Reference[], Object.values(this.bibliography.references));
 
 	constructor(style: Style, bibliography: Bibliography) {
 		this.style = style;
-		this.citeRefs = [];
-		this.bibliography = new Bibliography({});
+		//	this.citeRefs = CiteRef;
+		this.bibliography = bibliography;
 	}
 
-	addCiteRef(citeRef: CiteRef): void {
-		this.citeRefs.push(citeRef);
-	}
+	// addCiteRef(citeRef: CiteRef): void {
+	// 	this.citeRefs.push(citeRef);
+	// }
 
 	processCiteRefs(): void {
 		// 1. sort the references
@@ -39,9 +35,13 @@ export class Processor {
 		//  this.bibliography.process();
 	}
 
-	// private referencesArray = Object.values(this.bibliography);
-
-
+	getReferences(): Reference[] {
+		const refs = Object.values(this.bibliography.references);
+		const refsObjs = refs.map((ref) => {
+			return plainToClass(Reference, ref);
+		});
+		return refsObjs;
+	}
 }
 
 function normalizeString(str: string): string {

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,175 +1,61 @@
 import { Style, SortType, GroupSortType } from "./style";
-import { Reference, ID } from "./reference";
+import { Reference, ReferenceType, Title, ID } from "./reference";
 import { CiteRef } from "./citation";
-import { Bibliography } from "./bibliography";
-import { Type, plainToClass } from "class-transformer";
+import { InputBibliography } from "./bibliography";
+import { Contributor } from "./contributor";
 import "reflect-metadata";
+import { plainToClass } from "class-transformer";
 
 export class Processor {
 	style: Style;
 	//citeRefs: CiteRef[];
-	bibliography: Bibliography;
+	bibliography: InputBibliography;
 
-	constructor(style: Style, bibliography: Bibliography) {
+	constructor(style: Style, bibliography: InputBibliography) {
 		this.style = style;
 		//	this.citeRefs = CiteRef;
-		this.bibliography = bibliography;
+		this.bibliography = plainToClass(InputBibliography, bibliography);
 	}
 
-	// addCiteRef(citeRef: CiteRef): void {
-	// 	this.citeRefs.push(citeRef);
-	// }
-
-	processCiteRefs(): void {
-		// 1. sort the references
-		// 2. add the references to the bibliography
-		// 3. add the citeRefs to the bibliography
-		// 4. process the bibliography
-		// 5. return the bibliography
-		// const sortedReferences = sortReferences(
-		//  this.style.sort,
-		//  this.references
-		// );
-		// this.bibliography.addReferences(sortedReferences);
-		// this.bibliography.addCiteRefs(this.citeRefs);
-		//  this.bibliography.process();
-	}
-
-	getReferences(): Reference[] {
-		const refs = Object.values(this.bibliography.references);
+	getProcReferences(): ProcReference[] {
+		const refs = Object.values(this.bibliography);
 		const refsObjs = refs.map((ref) => {
-			return plainToClass(Reference, ref);
+			return plainToClass(ProcReference, ref);
 		});
 		return refsObjs;
 	}
 }
 
-function normalizeString(str: string): string {
-	return str.replace(/ /g, "-").replace(/,/g, "").toLowerCase();
-}
+export class ProcReference extends Reference {
+	disambCondition?: boolean;
+	sortKeys?: string[];
+	disambYearSuffix?: number;
+	disambEtAlNames?: boolean;
 
-function sortReferences(
-	keys: SortType[],
-	references: Reference[],
-): Reference[] {
-	// sort the references by keys
-	//   1. sort by first key
-	//   2. sort by second key
-	//   3. etc.
-	//   4. return the sorted references
-	//   5. if no keys, return the references as-is
-	if (keys.length === 0) {
-		return references;
-	} else {
-		const key = keys[0];
-		const sortedReferences = references.sort((a, b) => {
-			const aKey = getSortKey(key, a);
-			const bKey = getSortKey(key, b);
-			if (aKey < bKey) {
-				return -1;
-			} else if (aKey > bKey) {
-				return 1;
-			} else {
-				return 0;
-			}
-		});
-		return sortedReferences;
+	constructor(
+		id: ID,
+		type: ReferenceType,
+		title: Title,
+		author: Contributor[],
+		editor: Contributor[],
+		disambCondition?: boolean,
+		sortKeys?: string[],
+		disambYearSuffix?: number,
+		disambEtAlNames?: boolean,
+	) {
+		super(id, type, title, author, editor);
+		this.disambCondition = disambCondition;
+		this.sortKeys = sortKeys;
+		this.disambYearSuffix = disambYearSuffix;
+		this.disambEtAlNames = disambEtAlNames;
 	}
-}
 
-// write a function that sorts a Reference object by a single key
-//   (use the normalizeString function to normalize strings)
-function sortReferencesByKey(
-	sorter: SortType,
-	references: Reference[],
-): Reference[] {
-	// sort the references by key
-	//   1. sort by key
-	//   2. return the sorted references
-	//   3. if no key, return the references as-is
-	if (sorter.key === undefined) {
-		return references;
-	} else {
-		const sortedReferences = references.sort((a, b) => {
-			const aKey = getSortKey(sorter, a);
-			const bKey = getSortKey(sorter, b);
-			if (aKey < bKey) {
-				return -1;
-			} else if (aKey > bKey) {
-				return 1;
-			} else {
-				return 0;
-			}
-		});
-		return sortedReferences;
+	formatContributors(contributors: Contributor[]): string {
+		const contribArray = contributors.map((contributor) => contributor.name);
+		return contribArray.join(", ");
 	}
-}
 
-// write a function that sortsa list of Reference objects by a single key
-//   (use the normalizeString function to normalize strings)
-
-// TODO write a function that groups references by keys
-function groupReferences(
-	keys: GroupSortType[],
-	references: Reference[],
-): Reference[] {
-	// write the grouping logic by keys
-	//   1. group by first key
-	//   2. group by second key
-	//   3. etc.
-	//   4. return the grouped references
-	//   5. if no keys, return the references as-is
-	if (keys.length === 0) {
-		return references;
-	} else {
-		return references;
+	formatAuthors(): string {
+		return this.formatContributors(this.author);
 	}
-}
-
-function getSortKey(sort: SortType, reference: Reference): string {
-	switch (sort.key) {
-		case "author":
-			if (reference.author !== undefined) {
-				return reference.author[0].sortName();
-			}
-		case "year":
-			return ""; // TODO
-		case "as-cited":
-			return reference.id; // FIX
-		default:
-			return "";
-	}
-}
-
-// TODO write a function that returns the position of a reference in a list of cited references
-function citedReferencePosition(citedRef: CiteRef): number {
-	return 1; // placeholder
-}
-
-// TODO write a function that takes references and sorts and groups on keys
-function sortAndGroup(
-	groupBy: GroupSortType[],
-	sort: SortType[],
-	references: Reference[],
-): Reference[] {
-	const sortedReferences = sortReferences(sort, references);
-	const groupedReferences = groupReferences(groupBy, sortedReferences);
-	return groupedReferences;
-}
-
-// TODO write a function that takes references and sorts and groups on keys
-function sortAndGroupCited(
-	groupBy: GroupSortType[],
-	sort: SortType[],
-	references: Reference[],
-	citedRefs: CiteRef[],
-): Reference[] {
-	const sortedReferences = sortReferences(sort, references);
-	const groupedReferences = groupReferences(groupBy, sortedReferences);
-	return groupedReferences;
-}
-
-export { sortAndGroup, sortAndGroupCited, citedReferencePosition };
-function a(a: Reference, b: Reference): number {
-	throw new Error("Function not implemented.");
 }

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -2,11 +2,17 @@ import { Style, SortType, GroupSortType } from "./style";
 import { Reference, ID } from "./reference";
 import { CiteRef } from "./citation";
 import { Bibliography } from "./bibliography";
+import { plainToClass } from "class-transformer";
+import "reflect-metadata";
 
 export class Processor {
 	style: Style;
 	citeRefs: CiteRef[];
 	bibliography: Bibliography;
+	// convert to array, and then to class instances
+	// TODO this seems to work, but linter is saying it shouldn't
+	//   also, this should only load from the CiteKeys in the CiteRefs
+	private _references: plainToClass(Reference[], Object.values(this.bibliography.references));
 
 	constructor(style: Style, bibliography: Bibliography) {
 		this.style = style;
@@ -33,9 +39,9 @@ export class Processor {
 		//  this.bibliography.process();
 	}
 
-	getBibliography(): Bibliography {
-		return this.bibliography;
-	}
+	// private referencesArray = Object.values(this.bibliography);
+
+
 }
 
 function normalizeString(str: string): string {

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -5,15 +5,13 @@ import { Bibliography } from "./bibliography";
 
 export class Processor {
 	style: Style;
-	references: Reference[];
 	citeRefs: CiteRef[];
 	bibliography: Bibliography;
 
-	constructor(style: Style, references: Reference[]) {
+	constructor(style: Style, bibliography: Bibliography) {
 		this.style = style;
-		this.references = references;
 		this.citeRefs = [];
-		this.bibliography = new Bibliography();
+		this.bibliography = new Bibliography({});
 	}
 
 	addCiteRef(citeRef: CiteRef): void {

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,8 +1,6 @@
 // Typescript model for a CSL Reference
 
-import { Expose, Type } from "class-transformer";
-import "reflect-metadata";
-import { Contributor, Organization, Person } from "./contributor";
+import { Contributor } from "./contributor";
 
 // Types
 
@@ -41,44 +39,17 @@ export interface TitleStructured {
 }
 
 export class Reference {
-	id: ID;
-	type: ReferenceType;
-	title: Title;
-
-	@Type(() => Contributor, {
-    discriminator: {
-      property: 'type',
-      subTypes: [
-        { value: Person, name: 'person' },
-        { value: Organization, name: 'organization' },  ],
-    },
-  })
-	author?: (Person | Organization)[];
-	editor?: Contributor[];
-	publisher?: Contributor[];
-	issued?: CSLDate;
-	abstract?: string;
-	accessed?: CSLDate;
-
 	constructor(
-		id: ID,
-		type: ReferenceType,
-		title: Title,
-		author?: (Person | Organization)[],
-		editor?: Contributor[],
-		publisher?: Contributor[],
-		issued?: CSLDate,
-		abstract?: string,
-		accessed?: CSLDate,
+		public id: ID,
+		public type: ReferenceType,
+		public title: Title,
+		public author: Contributor[],
+		public editor?: Contributor[],
 	) {
 		this.id = id;
 		this.type = type;
 		this.title = title;
 		this.author = author;
 		this.editor = editor;
-		this.publisher = publisher;
-		this.issued = issued;
-		this.abstract = abstract;
-		this.accessed = accessed;
 	}
 }

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,6 +1,6 @@
 // Typescript model for a CSL Reference
 
-import { Type } from "class-transformer";
+import { Expose, Type } from "class-transformer";
 import "reflect-metadata";
 import { Contributor, Organization, Person } from "./contributor";
 
@@ -21,6 +21,8 @@ export type CSLDate = EDTFDATE;
 export type EDTFDATE = string | null | undefined;
 
 export type ID = string; // string needs to be a token
+
+export type IDReference = Record<ID, Reference>;
 
 export type ReferenceType = "book" | "article" | "chapter";
 
@@ -43,6 +45,7 @@ export class Reference {
 	type: ReferenceType;
 	title: Title;
 
+	@Expose
 	@Type(() => Contributor, {
     discriminator: {
       property: 'type',

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -45,7 +45,6 @@ export class Reference {
 	type: ReferenceType;
 	title: Title;
 
-	@Expose
 	@Type(() => Contributor, {
     discriminator: {
       property: 'type',
@@ -61,15 +60,25 @@ export class Reference {
 	abstract?: string;
 	accessed?: CSLDate;
 
-	constructor(id: ID, type: ReferenceType, title: Title) {
+	constructor(
+		id: ID,
+		type: ReferenceType,
+		title: Title,
+		author?: (Person | Organization)[],
+		editor?: Contributor[],
+		publisher?: Contributor[],
+		issued?: CSLDate,
+		abstract?: string,
+		accessed?: CSLDate,
+	) {
 		this.id = id;
 		this.type = type;
 		this.title = title;
-		this.author = [];
-		this.editor = [];
-		this.publisher = [];
-		this.issued = "";
-		this.abstract = "";
-		this.accessed = "";
+		this.author = author;
+		this.editor = editor;
+		this.publisher = publisher;
+		this.issued = issued;
+		this.abstract = abstract;
+		this.accessed = accessed;
 	}
 }


### PR DESCRIPTION
I struggled to get `class-transformer` to property type the nested objects in the revised `Bibliography` model.

Finally got it working reasonably.

```typescript
[
  ProcReference {
    id: 'doe1',
    type: 'book',
    title: 'The Title',
    author: [ [Object] ],
    editor: undefined,
    disambCondition: undefined,
    sortKeys: undefined,
    disambYearSuffix: undefined,
    disambEtAlNames: undefined,
    issued: '2023'
  },
```

Close: #47 
