### PR TITLE
refactor: `Reference` to interface, remove `id`

### DIFF
--- a/examples/bibliography.yaml
+++ b/examples/bibliography.yaml
@@ -1,33 +1,28 @@
 doc1:
-  id: doe1
   type: book
   title: The Title
   author:
     - name: Doe, Jane
   issued: '2023'
 smith1:
-  id: smith1
   type: book
   title: The Title
   author:
     - name: Smith, Sam
   issued: '2023'
 doe2:
-  id: doe2
   type: book
   title: The Title
   author:
     - name: Doe, Jane
   issued: '2023'
 doe3:
-  id: doe3
   type: article
   title: The Title
   author:
     - name: Doe, Jane
   issued: '2022'
 un:
-  id: un
   type: article
   title: The Title
   author:

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -28,7 +28,23 @@ export class Processor {
 	}
 }
 
-export class ProcReference extends Reference {
+/**
+ * Data provided during processing to facilitate sorting and disambiguation.
+ */
+interface ProcHints {
+	citekey: ID;
+	disambCondition?: boolean;
+	sortKeys?: string[];
+	disambYearSuffix?: number;
+	disambEtAlNames?: boolean;
+}
+
+export class ProcReference implements ProcHints, Reference {
+	type: ReferenceType;
+	title: Title;
+	author: Contributor[];
+	editor: Contributor[];
+	// REVIEW maybe put the below in a common object instead?
 	citekey: ID;
 	disambCondition?: boolean;
 	sortKeys?: string[];
@@ -45,7 +61,10 @@ export class ProcReference extends Reference {
 		disambYearSuffix?: number,
 		disambEtAlNames?: boolean,
 	) {
-		super(type, title, author, editor);
+		this.type = type;
+		this.title = title;
+		this.author = author;
+		this.editor = editor;
 		this.citekey = this.citekey;
 		this.disambCondition = disambCondition;
 		this.sortKeys = sortKeys;

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -18,22 +18,24 @@ export class Processor {
 	}
 
 	getProcReferences(): ProcReference[] {
-		const refs = Object.values(this.bibliography);
-		const refsObjs = refs.map((ref) => {
-			return plainToClass(ProcReference, ref);
+		const citekeys = Object.keys(this.bibliography);
+		const refsObjs = citekeys.map((citekey) => {
+			const pref = plainToClass(ProcReference, this.bibliography[citekey]);
+			pref.citekey = citekey;
+			return pref;
 		});
 		return refsObjs;
 	}
 }
 
 export class ProcReference extends Reference {
+	citekey: ID;
 	disambCondition?: boolean;
 	sortKeys?: string[];
 	disambYearSuffix?: number;
 	disambEtAlNames?: boolean;
 
 	constructor(
-		id: ID,
 		type: ReferenceType,
 		title: Title,
 		author: Contributor[],
@@ -43,7 +45,8 @@ export class ProcReference extends Reference {
 		disambYearSuffix?: number,
 		disambEtAlNames?: boolean,
 	) {
-		super(id, type, title, author, editor);
+		super(type, title, author, editor);
+		this.citekey = this.citekey;
 		this.disambCondition = disambCondition;
 		this.sortKeys = sortKeys;
 		this.disambYearSuffix = disambYearSuffix;

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -40,13 +40,11 @@ export interface TitleStructured {
 
 export class Reference {
 	constructor(
-		public id: ID,
 		public type: ReferenceType,
 		public title: Title,
 		public author: Contributor[],
 		public editor?: Contributor[],
 	) {
-		this.id = id;
 		this.type = type;
 		this.title = title;
 		this.author = author;

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -38,16 +38,15 @@ export interface TitleStructured {
 	sub: TitleString[];
 }
 
-export class Reference {
-	constructor(
-		public type: ReferenceType,
-		public title: Title,
-		public author: Contributor[],
-		public editor?: Contributor[],
-	) {
-		this.type = type;
-		this.title = title;
-		this.author = author;
-		this.editor = editor;
-	}
+/**
+ * Input reference data.
+ */
+export interface Reference {
+	type?: ReferenceType;
+	title?: Title;
+	author?: Contributor[];
+	editor?: Contributor[];
+	issued?: CSLDate;
+	accessed?: CSLDate;
+	publisher?: string;
 }


### PR DESCRIPTION
Close: #78 

```typescript
  ProcReference {
    type: 'article',
    title: 'The Title',
    author: [ [Object] ],
    editor: undefined,
    citekey: 'un',
    disambCondition: undefined,
    sortKeys: undefined,
    disambYearSuffix: undefined,
    disambEtAlNames: undefined,
    issued: '2020'
  }
```