### PR TITLE
ContributorListFormatting group

### DIFF
--- a/examples/style.csl.yaml
+++ b/examples/style.csl.yaml
@@ -4,11 +4,15 @@
 title: APA
 options:
   # localized date formatting config
-  dateFormatting:
+  dates:
     date: long
     month: long
     time: long
     year: numeric
+  contributors:
+    andAnd: text
+    delimiterPrecedesEtAl: contextual
+    delimiterPrecedesLast: contextual
   # REVIEW: I think this belongs in `group`
   disambiguate:
     addNames: all-with-initials

--- a/examples/style.csl.yaml
+++ b/examples/style.csl.yaml
@@ -20,8 +20,8 @@ options:
       order: ascending
   group:
     # be explicit about grouping, which is core logic
-    - key: author
-    - key: year
+    - author
+    - year
   # pave the way for multilingual support
   localization:
     scope: global
@@ -40,12 +40,12 @@ citation:
       - key: year
         order: descending # in CSL 1.0, we have this global, but it's specific to citations
     group:
-      - key: author
-      - key: year
+      - author
+      - year
   integral:
     options:
       group:
-        - key: author
+        - author
     format:
       - template: author-apa
       - wrap: parentheses

--- a/src/style.ts
+++ b/src/style.ts
@@ -186,7 +186,11 @@ export interface OptionGroup {
 	/**
 	 * Date formatting configuration.
 	 */
-	dateFormatting?: DateFormatting;
+	dates?: DateFormatting;
+	/**
+	 * Contributor list formatting configuration.
+	 */
+	contributors?: ContributorListFormatting;
 }
 
 /**
@@ -301,6 +305,100 @@ type MonthStyle =
 	| "long" // (e.g., March)
 	| "short" // (e.g., Mar)
 	| "narrow"; // (e.g., M).
+
+export type AndAsType = "text" | "symbol";
+export interface ContributorListFormatting {
+	/**
+	 * The delimiter between last and second-to-last item.
+	 *
+	 * The default "text" value produces:
+	 *
+	 * >  Doe, Johnson and Smith
+	 *
+	 * The "symbol" value produces:
+	 *
+	 * >  Doe, Johnson & Smith
+	 *
+	 * @default text
+	 */
+	andAs?: AndAsType;
+
+	/**
+	 * Determines when the delimiter is used to separate the second to last and the last
+	 * item in contributor lists (if `and` is not set, the name delimiter is always used,
+	 * regardless of the value of `delimiterPrecedesLast`). Allowed values:
+	 *
+	 * ### `contextual`
+	 *
+	 * The contributor delimiter is only used for lists of three or more:
+	 *
+	 *   - 2 names: “J. Doe and T. Williams”
+	 *   - 3 names: “J. Doe, S. Smith, and T. Williams”
+	 *
+	 * ### `after-inverted-name`
+	 *
+	 * Delimiter is only used if the preceding name is inverted as a result of the
+	 * `asSort` parameter. E.g. with `asSort` set to “first”:
+	 *
+	 *   - “Doe, J., and T. Williams”
+	 *   -  “Doe, J., S. Smith and T. Williams”
+	 *
+	 * ### `always`
+	 *
+	 * Delimiter is always used:
+	 *
+	 *  - 2 names: “J. Doe, and T. Williams”
+	 *  - 3 names: “J. Doe, S. Smith, and T. Williams”
+	 *
+	 * ### `never`
+	 *
+	 * Delimiter is never used:
+	 *
+	 *   - 2 names: “J. Doe and T. Williams”
+	 *   - 3 names: “J. Doe, S. Smith and T. Williams”
+	 *
+	 * @default contextual
+	 */
+	delimiterPrecedesLast?: "always" | "never" | "contextual";
+	/**
+	 * Determines when the delimiter or a space is used between a truncated contributor list
+	 * and the “et-al” (or “and others”) term in case of et-al abbreviation.
+	 *
+	 * Allowed values:
+	 * 
+	 * ### `contextual`
+	 * 
+	 * Delimiter is only used for contributor lists truncated to two or more items:
+
+	 *   - 1 name: “J. Doe et al.”
+	 *   - 2 names: “J. Doe, S. Smith, et al.”
+	 * 
+	 * ### `after-inverted-name`
+	 * 
+	 * Delimiter is only used if the preceding name is inverted as a result of the `asSort` parameter. 
+	 * E.g. with `asSort` set to “first”:
+	 * 
+	 *   - “Doe, J., et al.”
+	 *   - “Doe, J., S. Smith et al.”
+	 *  
+	 * ### `always`
+	 * 
+	 * Delimiter is always used:
+	 * 
+	 *   - 1 name: “J. Doe, et al.”
+	 *   - 2 names: “J. Doe, S. Smith, et al.”
+	 * 
+	 * ### `never`
+	 * 
+	 * Delimiter is never used:
+	 *   - 1 name: “J. Doe et al.”
+	 *   - 2 names: “J. Doe, S. Smith et al.”
+	 *
+	 * @default contextual
+	 */
+	delimiterPrecedesEtAl?: "always" | "never" | "contextual";
+}
+
 /**
  * A CSL Style.
  */

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,13 +1,9 @@
 {
-  "entryPoints": [
-    "./src/citation.ts",
-    "./src/bibliography.ts",
-    "./src/style.ts",
-    "./src/locator.ts",
-    "./src/reference.ts",
-    "./src/processor.ts"
-  ],
-  "umlClassDiagram": {
-    "arrowColor": "gray"
-  }
+	"entryPoints": [
+		"./src/citation.ts", "./src/bibliography.ts", "./src/style.ts",
+		"./src/locator.ts", "./src/reference.ts", "./src/processor.ts"
+	],
+	"umlClassDiagram": {
+		"arrowColor": "gray"
+	}
 }


### PR DESCRIPTION
This is just adapting the names stuff from 1.0 schema and spec to this, including the documentation.

So no names template structure here; just parameters.

These are the default values, as inserted by `VSCode`:

```yaml
  contributors:
    andAnd: text
    delimiterPrecedesEtAl: contextual
    delimiterPrecedesLast: contextual
```

I do need to revise the docs to use more of the typedoc features:

https://typedoc.org/tags/param/

Open question: whether some of this might apply to lists beyond contributors?

![image](https://user-images.githubusercontent.com/1134/236632397-b34ff511-cb48-449a-9617-b5e7ffc5e7aa.png)

Close: #67 