### PR TITLE
refactor: add ts extension to import statements

### DIFF
--- a/src/bibliography.ts
+++ b/src/bibliography.ts
@@ -1,4 +1,4 @@
-import { InputReference, ID } from "./reference";
+import { InputReference, ID } from "./reference.ts";
 import "reflect-metadata";
 import { plainToClass } from "class-transformer";
 

--- a/src/citation.ts
+++ b/src/citation.ts
@@ -1,4 +1,4 @@
-import { ID } from "./reference";
+import { ID } from "./reference.ts";
 
 type CitationModeType = "integral" | "nonIntegral";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
-import { InputBibliography } from "./bibliography";
-import { Style } from "./style";
-import { Processor } from "./processor";
+import { InputBibliography } from "./bibliography.ts";
+import { Style } from "./style.ts";
+import { Processor } from "./processor.ts";
 //import { Reference } from "./reference";
-import { loadJSON, loadYAML } from "./utils";
+import { loadJSON, loadYAML } from "./utils.ts";
 
 const biby = loadYAML("examples/bibliography.yaml") as InputBibliography;
 

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,8 +1,8 @@
-import { Style, ReferenceTypes, SortRules, GroupSortKeys } from "./style";
-import { InputReference, Title, ID } from "./reference";
-import { CiteRef } from "./citation";
-import { InputBibliography } from "./bibliography";
-import { Contributor } from "./contributor";
+import { Style, ReferenceTypes, SortRules, GroupSortKeys } from "./style.ts";
+import { InputReference, Title, ID } from "./reference.ts";
+import { CiteRef } from "./citation.ts";
+import { InputBibliography } from "./bibliography.ts";
+import { Contributor } from "./contributor.ts";
 import "reflect-metadata";
 import { plainToClass } from "class-transformer";
 

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -1,7 +1,7 @@
 // Typescript model for a CSL Reference
 
-import { Contributor } from "./contributor";
-import { ReferenceTypes, ContributorRoles } from "./style";
+import { Contributor } from "./contributor.ts";
+import { ReferenceTypes, ContributorRoles } from "./style.ts";
 
 // Types
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "node:fs";
 import { parse } from "yaml";
 
 export function loadJSON(path: string): object {


### PR DESCRIPTION
For deno compatibility add extensions to the src file import statements.

Also, use `node:fs` for import on `fs`.

Close: #68 

----------

This appears to not break anything, so perhaps I only need to add an import map and `deno.json` config for full compatibility?