### PR TITLE
template, locale refactoring

### DIFF
--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,4 +1,4 @@
-// REVIEW not sure where best to do this
+// REVIEW replace with https://esm.sh/locale-enum@1.1.1
 type Lang =
   | "af-ZA"
   | "ar"
@@ -48,27 +48,121 @@ type Lang =
   | "zh-CN"
   | "zh-TW";
 
-export interface Locale {
+/**
+ * The unique human-readable identifier for a term.
+ */
+export type LocalizedTermName =
+  | LocalizedTermNameLocator
+  | LocalizedTermNameLocatorNumber
+  | LocalizedTermNameMisc;
+
+export type LocalizedTermNameMisc =
+  | "accessed"
+  | "ad"
+  | "advance-online-publication"
+  | "album"
+  | "and"
+  | "and-others"
+  | "anonymous"
+  | "at"
+  | "audio-recording"
+  | "available-at"
+  | "bc"
+  | "bce"
+  | "by"
+  | "ce"
+  | "circa"
+  | "cited"
+  | "et-al"
+  | "film"
+  | "forthcoming"
+  | "from"
+  | "henceforth"
+  | "ibid"
+  | "in"
+  | "in-press"
+  | "internet"
+  | "interview"
+  | "letter"
+  | "loc-cit"
+  | "no date"
+  | "no-place"
+  | "no-publisher"
+  | "on"
+  | "online"
+  | "op-cit"
+  | "original-work-published"
+  | "personal-communication"
+  | "podcast"
+  | "podcast-episode"
+  | "preprint"
+  | "presented-at"
+  | "radio-broadcast"
+  | "radio-series"
+  | "radio-series-episode"
+  | "reference"
+  | "retrieved"
+  | "review-of"
+  | "scale"
+  | "special-issue"
+  | "special-section"
+  | "television-broadcast"
+  | "television-series"
+  | "television-series-episode"
+  | "video"
+  | "working-paper";
+
+export type LocalizedTermNameLocator =
+  | "act"
+  | "appendix"
+  | "article-locator"
+  | "book"
+  | "canon"
+  | "chapter"
+  | "column"
+  | "elocation"
+  | "equation"
+  | "figure"
+  | "folio"
+  | "line"
+  | "note"
+  | "opus"
+  | "paragraph"
+  | "rule"
+  | "scene"
+  | "sub-verbo"
+  | "table"
+  | "timestamp"
+  | "title-locator"
+  | "verse";
+
+export type LocalizedTermNameLocatorNumber =
+  | "issue"
+  | "page"
+  | "part"
+  | "section"
+  | "supplement"
+  | "version"
+  | "volume";
+
+export type LocalizedTermFormat = "short" | "symbol";
+
+export interface Localization {
   title?: string;
   description?: string;
-  locale: Lang; // https://github.com/anton-bot/locale-enum
-  punctuationInQuote: boolean;
-  terms: Term[];
+  locale: Lang;
+  punctuationInQuote?: boolean;
+  terms: Record<LocalizedTermName, LocalizedTerm>;
 }
 
-export interface StandaloneLocale extends Locale {
+export interface StandaloneLocalize extends Localization {
   translators?: string[];
   description?: string;
   rights?: string; // use enum here, and in style
 }
 
-export interface Term {
-  name: string;
-  form?: "short" | "symbol";
+export interface LocalizedTerm {
+  format?: LocalizedTermFormat;
   single?: string;
   multiple?: string; // TODO this and above need to be coupled
-}
-
-export interface DateTerm extends Term {
-  dateParts: string[]; // TODO
 }

--- a/src/style.ts
+++ b/src/style.ts
@@ -77,6 +77,11 @@ export type TemplateModel =
   | Cond;
 
 /**
+ * An inline template that can be referenced by unique key.
+ */
+export type NamedTemplate = Record<CalledTemplate, InlineTemplate>;
+
+/**
  * The rendering of style templates can be specified by reference to a template name or by inline definition.
  */
 export type Template = CalledTemplate | InlineTemplate;
@@ -520,20 +525,6 @@ export interface Style {
    * The citation specification.
    */
   citation?: CitationStyle;
-}
-
-export interface NamedTemplate {
-  /**
-   * The name token for the template, for reference from other templates.
-   */
-  name: string;
-  options?: OptionGroup;
-  template: /**
-     * The rendering instructions.
-     *
-     * @items.minimum 1
-     */
-    InlineTemplate; // REVIEW
 }
 
 interface RenderItemTemplate extends HasFormatting {

--- a/src/style.ts
+++ b/src/style.ts
@@ -1,3 +1,4 @@
+import { LocalizedTermFormat, LocalizedTermName } from "./locale.ts";
 /**
  * The CSL NEXT style model.
  */
@@ -565,8 +566,8 @@ interface RenderText extends HasFormatting {
  * Localized strings.
  */
 interface RenderTerm extends HasFormatting {
-  term: string; // REVIEW tighten this?
-  format: string; // TODO
+  term: LocalizedTermName;
+  format: LocalizedTermFormat;
 }
 
 interface RenderItemDate extends HasFormatting {

--- a/src/style.ts
+++ b/src/style.ts
@@ -72,6 +72,8 @@ export type TemplateModel =
   | RenderLocators
   | RenderItemDate
   | RenderTitle
+  | RenderText
+  | RenderTerm
   | Cond;
 
 /**
@@ -559,6 +561,21 @@ interface RenderListBlock extends RenderList {
 
 interface RenderItemSimple extends HasFormatting {
   variable: SimpleTypes;
+}
+
+/**
+ * Non-localized plain text.
+ */
+interface RenderText extends HasFormatting {
+  text: string;
+}
+
+/**
+ * Localized strings.
+ */
+interface RenderTerm extends HasFormatting {
+  term: string; // REVIEW tighten this?
+  format: string; // TODO
 }
 
 interface RenderItemDate extends HasFormatting {


### PR DESCRIPTION
Close: #45 #103

------------

WIP. 

On locales, would now be:

```yaml
title: a locale file
description: foo bar
locale: en-US
punctuationInQuote: true
terms:
  available:
    single: available
```

Still TBD: how much more of 1.0 I need to port, given the enhanced localization options here.

Also, still need to think about this alternative on this, which is the idea that terms are always attached to other pieces of rendered content. Perhaps there are other ways to handle that though (like, terms and text don't render within a list unless other content does).

```yaml
- template: container-apa
  prefix:
    term: in
    emph: true
```