### PR TITLE
chore: add bibliography style out

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,3 +12,6 @@ const refs = CiteProc.getProcReferences();
 console.log(CiteProc);
 console.log(CiteProc.getProcReferences());
 console.log(refs[2].formatAuthors());
+
+console.log("\nBibliography style spec:\n");
+console.log(CiteProc.style.bibliography);

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -86,4 +86,19 @@ export class ProcReference implements ProcHints, InputReference {
   formatAuthors(): string {
     return this.formatContributors(this.author);
   }
+
+  // write a method to render to string from the AST
+
+  // toDjotAST(
+  //   /**
+  //    * Global style options.
+  //    */
+  //   globalOptions: {},
+  //   /**
+  //    * The citation or bibliography style object
+  //    */
+  //   renderSpecs: {}): [] {
+  //   // use Array.reduce to build up the AST
+  //   return [];  // TODO
+  // }
 }


### PR DESCRIPTION
Mostly just adding a commented out placeholder for a `toDjotAST` method.

But enhancing the cli output a bit.