### PR TITLE
restart of render

### DIFF
--- a/examples/style.csl.yaml
+++ b/examples/style.csl.yaml
@@ -4,7 +4,14 @@
 title: APA
 templates:
   title-apa:
-    title: title
+    - title: title
+  author-apa-full:
+    - contributors: author
+  container-apa:
+    - title: container-title
+  howpublished-apa:
+    - contributors: publisher
+      wrap: parentheses
 options:
   # all of the below parameter options will have reasonable defaults
   # localized date formatting config
@@ -80,6 +87,6 @@ bibliography:
       - date: issued
         format: year
         wrap: parentheses
-      - templateKey: title
+      - templateKey: title-apa
       - templateKey: container-apa
       - templateKey: howpublished-apa

--- a/examples/style.csl.yaml
+++ b/examples/style.csl.yaml
@@ -1,7 +1,10 @@
-# yaml-language-server: $schema=/home/bruce/Code/csl-next.js/schemas/csl-style-schema.yaml
+# yaml-language-server: $schema=/home/bruce/Code/csl-next.js/schemas/csl-style-schema.json
 ---
 # this is a flatter model, relying more heavily on parameters
 title: APA
+templates:
+  title-apa:
+    title: title
 options:
   # all of the below parameter options will have reasonable defaults
   # localized date formatting config

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,12 +9,7 @@ const biby = loadBibliography(
 const csly = loadStyle("examples/style.csl.yaml");
 
 const CiteProc = new Processor(csly, biby);
-const refs = CiteProc.getProcReferences();
+//const refs = CiteProc.getProcReferences();
 
-console.log(CiteProc);
-console.log(CiteProc.getProcReferences());
-console.log(refs[2].formatAuthors());
-
-console.log("\nBibliography style spec:\n");
-console.log(CiteProc.style.bibliography);
+console.log("\nIntermediate rendering of bibliography, using example style:\n");
 console.log(CiteProc.renderReferences());

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,3 +17,4 @@ console.log(refs[2].formatAuthors());
 
 console.log("\nBibliography style spec:\n");
 console.log(CiteProc.style.bibliography);
+console.log(CiteProc.renderReferences());

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,12 +1,8 @@
-import {
-  HasFormatting,
-  InlineTemplate,
-  ReferenceTypes,
-  Style,
-} from "./style.ts";
+import { HasFormatting, ReferenceTypes, Style } from "./style.ts";
+import { InlineTemplate } from "./style/template.ts";
 import { ID, InputReference, Title } from "./reference.ts";
 import { InputBibliography } from "./bibliography.ts";
-import { Contributor } from "./contributor.ts";
+import { Contributor } from "./style/contributor.ts";
 import { _reflect } from "../deps.ts";
 import { plainToClass } from "../deps.ts";
 
@@ -68,7 +64,7 @@ export class Processor {
   private renderReference(
     reference: ProcReference,
   ): ProcTemplate[] {
-    const template = this.style.bibliography!.format as InlineTemplate;
+    const template = this.style.bibliography!.template as InlineTemplate;
     const result = template.map((component) => {
       const cres = {
         ...component,
@@ -102,7 +98,7 @@ export class Processor {
   renderBibliography(): ProcTemplate[] {
     if (this.style.bibliography) {
       return this.renderReferences(
-        this.style.bibliography!.format as InlineTemplate,
+        this.style.bibliography!.template as InlineTemplate,
       );
     }
     return [];

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,5 +1,5 @@
 import { HasFormatting, ReferenceTypes, Style } from "./style.ts";
-import { InlineTemplate } from "./style/template.ts";
+import { InlineTemplate, TemplateComponent } from "./style/template.ts";
 import { ID, InputReference, Title } from "./reference.ts";
 import { InputBibliography } from "./bibliography.ts";
 import { Contributor } from "./style/contributor.ts";
@@ -61,29 +61,32 @@ export class Processor {
     reference: ProcReference,
     template: InlineTemplate[],
   ): ProcTemplate[] {
-    return template.map((component: InlineTemplate) => {
-      switch (true) {
-        case "title" in component:
-          return {
-            ...component,
-            procValue: reference[component.title as keyof ProcReference],
-          };
-        case "date" in component:
-          return {
-            ...component,
-            procValue: reference[component.date as keyof ProcReference],
-          };
-        case "contributor" in component:
-          return {
-            ...component,
-            procValue: reference[component.contributor as keyof ProcReference],
-          };
-        case "templates" in component:
-          return this.renderReference(reference, component.templates);
-        default:
-          return component;
-      }
-    });
+    const result = (() =>
+      template.map((component: TemplateComponent) => {
+        switch (true) {
+          case "title" in component:
+            return {
+              ...component,
+              procValue: reference[component.title as keyof ProcReference],
+            };
+          case "date" in component:
+            return {
+              ...component,
+              procValue: reference[component.date as keyof ProcReference],
+            };
+          case "contributor" in component:
+            return {
+              ...component,
+              procValue:
+                reference[component.contributor as keyof ProcReference],
+            };
+          case "templates" in component:
+            return this.renderReference(reference, component.templates);
+          default:
+            return component;
+        }
+      }))();
+    return result();
   }
 
   getProcReferences(): ProcReference[] {

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -59,34 +59,58 @@ export class Processor {
   // TODO: this should probably create rendering for both contexts at once.
   renderReference(
     reference: ProcReference,
-    template: InlineTemplate[],
+    template: TemplateComponent[],
   ): ProcTemplate[] {
-    const result = (() =>
-      template.map((component: TemplateComponent) => {
+    try {
+      const result = template.map((component: TemplateComponent) => {
         switch (true) {
-          case "title" in component:
-            return {
-              ...component,
-              procValue: reference[component.title as keyof ProcReference],
-            };
-          case "date" in component:
-            return {
-              ...component,
-              procValue: reference[component.date as keyof ProcReference],
-            };
-          case "contributor" in component:
-            return {
-              ...component,
-              procValue:
-                reference[component.contributor as keyof ProcReference],
-            };
+          case "title" in component: {
+            const title = reference[component.title as keyof ProcReference];
+            if (title !== undefined) {
+              return {
+                ...component,
+                procValue: title,
+              };
+            }
+            break;
+          }
+          case "date" in component: {
+            const date = reference[component.date as keyof ProcReference];
+            if (date !== undefined) {
+              return {
+                ...component,
+                procValue: date,
+              };
+            }
+            break;
+          }
+          case "contributors" in component: {
+            const contributors =
+              reference[component.contributors as keyof ProcReference];
+            if (contributors !== undefined) {
+              return {
+                ...component,
+                procValue: contributors,
+              };
+            }
+            break;
+          }
           case "templates" in component:
             return this.renderReference(reference, component.templates);
+          case "templateKey" in component: {
+            return this.renderReference(
+              reference,
+              this.getTemplate(component.templateKey),
+            );
+          } //return component.templateKey;
           default:
             return component;
         }
-      }))();
-    return result();
+      });
+      return result;
+    } catch (e) {
+      console.log("error: ", e);
+    }
   }
 
   getProcReferences(): ProcReference[] {
@@ -99,7 +123,16 @@ export class Processor {
     return references;
   }
 
-  //getTemplates(): InlineTemplate[] {
+  getTemplate(templateKey: string): InlineTemplate | undefined {
+    try {
+      const template = this.style.templates[templateKey];
+      return template;
+    } catch (e) {
+      console.log("error: ", e);
+    }
+  }
+
+  //getTemplate(templateKey: string): InlineTemplate {}
 }
 
 /**

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,3 +1,4 @@
+import { ReferenceTypes, Style } from "./style.ts";
 import { HasFormatting, ReferenceTypes, Style } from "./style.ts";
 import { InlineTemplate } from "./style/template.ts";
 import { ID, InputReference, Title } from "./reference.ts";

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,9 +1,36 @@
-import { ReferenceTypes, Style } from "./style.ts";
+import {
+  HasFormatting,
+  InlineTemplate,
+  ReferenceTypes,
+  Style,
+} from "./style.ts";
 import { ID, InputReference, Title } from "./reference.ts";
 import { InputBibliography } from "./bibliography.ts";
 import { Contributor } from "./contributor.ts";
 import { _reflect } from "../deps.ts";
 import { plainToClass } from "../deps.ts";
+
+// TODO this isn't right, but I need to separately set pre-rendered values fgor each context.
+export interface ProcContext extends HasFormatting {
+  renderedCitationReference: ProcTemplate;
+  renderedBibliographyReference: ProcTemplate;
+}
+
+/**
+ * A simplified AST for reference component rendering.
+ */
+export interface ProcTemplate extends HasFormatting {
+  /**
+   * The name of the variable or named template to render.
+   */
+  renderVariable: string;
+  /**
+   * The value to render.
+   *
+   * It can either be a plain string, or a string with Djot markup.
+   */
+  renderValue: string;
+}
 
 /**
  * Takes citatons, bibliography, and style, and produces a formatted bibliography.
@@ -19,14 +46,76 @@ export class Processor {
     this.bibliography = bibliography;
   }
 
+  /**
+   * Render a list of intermediate ProcReference objects.
+   */
+  renderReferences(): ProcTemplate[] {
+    const procRefs = this.getProcReferences();
+    const result = procRefs.map((procRef) => {
+      this.renderReference(procRef);
+    });
+    // FIX this type error
+    return result;
+  }
+
+  /**
+   * Render a single intermediate ProcReference object.
+   *
+   * @param reference The reference to render.
+   * @returns A ProcReference, rendered according to the context.
+   */
+  // TODO: this should probably create rendering for both contexts at once.
+  private renderReference(
+    reference: ProcReference,
+  ): ProcTemplate[] {
+    const template = this.style.bibliography!.format as InlineTemplate;
+    const result = template.map((component) => {
+      const cres = {
+        ...component,
+        renderedCitation: "TODO",
+        renderedBibliography: `${reference.title}-test`,
+      };
+      return cres;
+    });
+    return result;
+  }
+
+  // write a recursive mapping function to iterate through an InlineTemplate and render it to a ProcTemplate
+  private renderTemplate(
+    template: InlineTemplate,
+    reference: ProcReference,
+  ): ProcTemplate[] {
+    const result = template.map((component) => {
+      const cres = {
+        ...component,
+        renderCitation: "TODO",
+        renderedBibliography: `${reference.title}-test`,
+      };
+      return cres;
+    });
+    return result;
+  }
+
+  /**
+   * Render a bibliography.
+   */
+  renderBibliography(): ProcTemplate[] {
+    if (this.style.bibliography) {
+      return this.renderReferences(
+        this.style.bibliography!.format as InlineTemplate,
+      );
+    }
+    return [];
+  }
+
   getProcReferences(): ProcReference[] {
     const citekeys = Object.keys(this.bibliography);
-    const refsObjs = citekeys.map((citekey) => {
+    const references = citekeys.map((citekey) => {
       const pref = plainToClass(ProcReference, this.bibliography[citekey]);
       pref.citekey = citekey;
       return pref;
     });
-    return refsObjs;
+    return references;
   }
 }
 
@@ -79,6 +168,7 @@ export class ProcReference implements ProcHints, InputReference {
   }
 
   formatContributors(contributors: Contributor[]): string {
+    // TODO: substitution, shortening, etc.
     const contribArray = contributors.map((contributor) => contributor.name);
     return contribArray.join(", ");
   }

--- a/src/style/template.ts
+++ b/src/style/template.ts
@@ -32,52 +32,46 @@ export type MatchWhich = {
   match: "all" | "any" | "none";
 };
 
-// this is the structured template model
-export type TemplateModel =
+/** A component of a CSL style template. */
+export type TemplateComponent =
   | RenderList
   | CalledTemplate
-  | RenderItemSimple
+  | RenderSimple
   | RenderContributors
   | RenderLocators
-  | RenderItemDate
+  | RenderDate
   | RenderTitle
   | RenderText
   | RenderTerm
   | Cond;
 
-/**
- * The rendering of style templates can be specified by reference to a template name or by inline definition.
- */
+/** The rendering of style templates can be specified by reference to a template name or by inline definition. */
 export type Template = CalledTemplate | InlineTemplate;
 
 export type TemplateKey = string;
 
-/**
- * A global template that can be referenced by unique key.
- */
+/** A global template that can be referenced by unique key. */
 export type NamedTemplate = Record<TemplateKey, InlineTemplate>;
 
+/** Template property definition in the Style. */
 export interface TopLevelTemplate {
   templates: NamedTemplate;
 }
 
+/** A standlone template file. */
 export interface TemplateFile extends TopLevelTemplate {
   title?: string;
   description?: string;
 }
 
-/**
- * A template is called by name.
- */
+/** A template is called by name. */
 export interface CalledTemplate {
   templateKey: TemplateKey;
 }
 
-/**
- * A template that is defined inline.
- */
+/** A template defined inline. */
 export interface InlineTemplate {
-  template: TemplateModel[];
+  template: TemplateComponent[];
 }
 
 // eg liquid or mustache option for dev?
@@ -86,43 +80,31 @@ export interface InlineTemplate {
 // Conditional definitions
 
 export interface Cond {
-  /**
-   * For the first condition that is non-nil, format the children.
-   */
+  /** For the first condition that is non-nil, format the children. */
   when?: Condition[];
-  /**
-   * When all of the when conditions are nil, format the children.
-   */
+  /** When all of the when conditions are nil, format the children. */
   else?: Template; // REVIEW
 }
 
 export type Match = MatchWhich & Template;
 
 export interface IsNumber {
-  /**
-   * Is the item variable a number?
-   */
+  /** Is the item variable a number? */
   isNumber: Locators;
 }
 
 export interface IsEDTFDate {
-  /**
-   * Does the date conform to EDTF?
-   */
+  /** Does the date conform to EDTF? */
   isEDTFDate: Dates;
 }
 
 export interface IsRefType {
-  /**
-   * Is the item reference type among the listed reference types?
-   */
+  /** Is the item reference type among the listed reference types? */
   isRefType: ReferenceTypes[];
 }
 
 export interface HasVariable {
-  /**
-   * Does the item reference include one of the listed variables?
-   */
+  /** Does the item reference include one of the listed variables? */
   hasVariable: Variables[];
 }
 
@@ -137,55 +119,52 @@ export type DataMatch =
 export type Condition = Match & DataMatch;
 
 export interface Locale {
-  /**
-   * The item reference locale; to allow multilingual output.
-   */
+  /** The item reference locale; to allow multilingual output. */
   locale: string; // REVIEW; best place for this? Define the locale type
 }
 
-export type RenderList = Options & InlineTemplate;
+// REVIEW is this needed, and is this right?
+export interface RenderList extends Options, InlineTemplate{}
 
 // FIXME
-export type RenderListBlock = RenderList & {
+export interface RenderListBlock extends RenderList  {
   listStyle?: string; // TODO
-};
+}
 
-export interface RenderItemSimple extends HasFormatting {
+export interface RenderSimple extends HasFormatting {
   variable: SimpleTypes;
 }
 
-/**
- * Non-localized plain text.
- */
+/** Non-localized plain text. */
 export interface RenderText extends HasFormatting {
   text: string;
 }
 
-/**
- * Localized strings.
- */
+/** Localized strings. */
 export interface RenderTerm extends HasFormatting {
   term: LocalizedTermName;
   format: LocalizedTermFormat;
 }
 
-export interface RenderItemDate extends HasFormatting {
+/** A template component for rendering dates. */
+export interface RenderDate extends HasFormatting {
   date: Dates;
   // TODO align this with DateOptions
   format: DateFormat;
 }
 
+/** A template component for rendering title. */
 export interface RenderTitle extends HasFormatting {
   title: Titles;
   format?: "main" | "sub" | "full" | "short";
 }
-// FIXME
-export type RenderContributors = RenderList & {
-  contributor: ContributorRoles;
-  // REVIEW add format?
-};
 
-// FIXME
-export type RenderLocators = RenderList & {
+/** A template component for rendering contributors. */
+export interface RenderContributors extends RenderList {
+  contributor: ContributorRoles;
+}
+
+/** A template component for rendering locators. */
+export interface RenderLocators extends RenderList {
   locator: Locators;
-};
+}

--- a/src/style/template.ts
+++ b/src/style/template.ts
@@ -124,10 +124,10 @@ export interface Locale {
 }
 
 // REVIEW is this needed, and is this right?
-export interface RenderList extends Options, InlineTemplate{}
+export interface RenderList extends Options, InlineTemplate {}
 
 // FIXME
-export interface RenderListBlock extends RenderList  {
+export interface RenderListBlock extends RenderList {
   listStyle?: string; // TODO
 }
 


### PR DESCRIPTION
Very much WIP., picking up where I left off with #114.

## Plan

Basic plan is to iterate through the (ultimately sorted) array of `ProcReference` instances, and from there through the style templates, and return an array of  `ProcTemplate` objects, which are just the templates with added rendered strings.

```js
  [
    [ { contributors: "author", procValue: [ [Object] ] } ],
    {
      date: "issued",
      format: "year",
      wrap: "parentheses",
      procValue: "2020"
    },
    [ { title: "title", procValue: "The Title" } ],
    [ { title: "container-title", procValue: undefined } ],
    [
      {
        contributors: "publisher",
        wrap: "parentheses",
        procValue: undefined
      }
    ]
  ]
```

Then output to different final targets (plain text, maybe Djot and/or pandoc, HTML) would involve transforming that.

## Status

It's mostly working finally, but still need to:

1. run the transform functions on the input data to produce a consistent string as the value.
2. don't add the ProcTemplate unless there's a value.
3. handle both citation and bibliography, at least as a start
4. misc cleanup.