### PR TITLE
Format additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ The code here is a `typescript` project that:
    [quicktype](https://quicktype.io).
 2. provides a proof-of-concept processor implementation.
 
-A first draft of the model is almost complete, while the second currently just reads and serializes data and styles.
+A first draft of the model is almost complete, while the second currently can: 
+
+1. read data and styles
+2. process 1 into an intermediate AST (though this is incomplete)
 
 ### Schema-backed Editing
 

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -4,7 +4,7 @@ import { ID, InputReference, Title } from "./reference.ts";
 import { InputBibliography } from "./bibliography.ts";
 import { Contributor } from "./style/contributor.ts";
 import { _reflect } from "../deps.ts";
-import { plainToClass } from "../deps.ts";
+import { edtf, plainToClass } from "../deps.ts";
 
 // TODO this isn't right, but I need to separately set pre-rendered values fgor each context.
 export interface ProcContext extends HasFormatting {
@@ -77,9 +77,10 @@ export class Processor {
           case "date" in component: {
             const date = reference[component.date as keyof ProcReference];
             if (date !== undefined) {
+              const dateStr = reference.formatDate(date);
               return {
                 ...component,
-                procValue: date,
+                procValue: dateStr,
               };
             }
             break;
@@ -193,6 +194,13 @@ export class ProcReference implements ProcHints, InputReference {
 
   formatAuthors(): string {
     return this.formatContributors(this.author);
+  }
+
+  formatDate(date: string): string {
+    const parsedDate = edtf.default(date);
+    // TODO make this smarter, use toLocaleString or something.
+    const dateString = parsedDate.toString();
+    return dateString;
   }
 
   // write a method to render to string from the AST

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -86,11 +86,13 @@ export class Processor {
           }
           case "contributors" in component: {
             const contributors =
+              // REVIEW make sure this works for non-author contributors.
               reference[component.contributors as keyof ProcReference];
             if (contributors !== undefined) {
+              const resultStr = reference.formatContributors(contributors);
               return {
                 ...component,
-                procValue: contributors,
+                procValue: resultStr,
               };
             }
             break;


### PR DESCRIPTION
Followup to #115; adds basic format to string logic so the result is more:

```js
  [
    [ { contributors: "author", procValue: "Doe, Jane" } ],
    {
      date: "issued",
      format: "year",
      wrap: "parentheses",
      procValue: "2023"
    },
    [ { title: "title", procValue: "The Title" } ],
  ]
]
```

I'm going to merge this now, and tackle date details later, as it may also involve changes to `Style` date options.