### PR TITLE
feat(processor): add grouping

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
 export * as edtf from "https://esm.sh/edtf@4.4.1";
-export { plainToClass } from "https://esm.sh/class-transformer@0.5.1";
+//export { plainToClass } from "https://esm.sh/class-transformer@0.5.1";
 export * as yaml from "https://esm.sh/yaml@2.2.2";
 export * as _reflect from "https://esm.sh/reflect-metadata@0.1.13";
 


### PR DESCRIPTION
Created a merge conflict, and the GitHub merge resolution forced a merge commit.

Easier to start over.

Here's the result currently:

```typescript
  ProcReference {
    data: {
      type: "article",
      title: "The Title",
      author: [ { name: "United Nations", parse: false } ],
      issued: "2020",
      citekey: "un"
    },
    procHints: { groupIndex: 1, groupKey: "United Nations:2019", groupLength: 1 }
  }
```