### PR TITLE
chore(CI): add commit msg check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,3 +29,16 @@ jobs:
           deno-version: v1.x # Run with latest stable Deno.
       - run: deno fmt --check src/*.ts
       - run: deno lint src/*.ts
+
+  cog_check_job:
+    runs-on: ubuntu-latest
+    name: check conventional commit compliance
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          # pick the pr HEAD instead of the merge commit
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Conventional commit check
+        uses: cocogitto/cocogitto-action@v3


### PR DESCRIPTION
Not sure this is the best option, but using `cocogitto` for commit msg linting.

One reason is it has other features, like auto-bumping. 