### PR TITLE
Add changelog generator

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,22 @@
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }} ({{ datetime "2006-01-02" .Tag.Date }})
+
+{{ range .CommitGroups -}}
+### {{ .Title }}
+
+{{ range .Commits -}}
+* {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }} ([{{ .Hash.Short }}]({{ $.Info.RepositoryURL }}/commit/{{ .Hash.Short }}))
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,28 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/bdarcus/csl-next
+options:
+  commits:
+    filters:
+      Type:
+        - feat
+        - fix
+        - refactor
+  commit_groups:
+    group_by: Type
+    sort_by: Title
+    title_maps:
+      feat: Added
+      fix: Fixed
+      refactor: Changed
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ examples/*.json
 play
 .vscode
 npm
-.chglog


### PR DESCRIPTION
Add config for `git-chnglog`, but don't do anything with it for now.  

Can be useful for adjusting the commit messages going forward, and can then integrate it into the CI after another tag or two.

Example below., which more-or-less follows the [common changelog](https://common-changelog.org/) guidelines.

Oddly, I rewrote recent history a bit to get the commit messages better aligned with this, but it's now using the original commits somehow!

-----------------


<a name="0.2.0"></a>
## [0.2.0](https://github.com/bdarcus/csl-next/compare/0.1.0...0.2.0) (2023-05-23)

### Added

* **processor:** year disambiguation ([c0917a2](https://github.com/bdarcus/csl-next/commit/c0917a2))
* **processor:** grouping ([26928c1](https://github.com/bdarcus/csl-next/commit/26928c1))
* **processor:** sorting ([87b096d](https://github.com/bdarcus/csl-next/commit/87b096d))
* **style:** OptionsFile ([0c43cd1](https://github.com/bdarcus/csl-next/commit/0c43cd1))

### Changed

* **citation:** make suffix an array again ([a83b6af](https://github.com/bdarcus/csl-next/commit/a83b6af))

### Fixed

* **processor:** date year ([12ce96f](https://github.com/bdarcus/csl-next/commit/12ce96f))
* **processor:** avoid empty array results ([5c3b37c](https://github.com/bdarcus/csl-next/commit/5c3b37c))
* **style:** import statement ([f0836df](https://github.com/bdarcus/csl-next/commit/f0836df))

