### PR TITLE
chore(CI): add schemas

### DIFF
--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -1,0 +1,21 @@
+# update json schemas when tagged
+name: Update schemas
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Update schemas
+        uses: denoland/setup-deno@v1.1.1
+        with:
+          deno-version: v1.x
+      - run: deno task schemas
+

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -4,7 +4,7 @@ import { build, emptyDir } from "https://deno.land/x/dnt/mod.ts";
 await emptyDir("./npm");
 
 await build({
-  packageManager: "pnpm",
+  packageManager: "npm",
   typeCheck: false,
   test: false,
   entryPoints: [


### PR DESCRIPTION
Not super sure on the details of this, but the idea is any time the repo is tagged, it runs `deno task schemas`, and so updates the json schemas.

Hard to test on the branch, since I'm not tagging.

EDIT: I'm closing this because I don't have time/patience to figure it out! Can come back to it later.